### PR TITLE
Add Android remote-config app and Firebase APK workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,33 @@
+name: Android APK and Firebase distribution
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Build debug APK
+        run: gradle :app:assembleDebug
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+      - name: Upload to Firebase App Distribution
+        if: ${{ secrets.FIREBASE_APP_ID != '' && secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 != '' }}
+        env:
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_SERVICE_ACCOUNT_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}
+        run: |
+          echo "$FIREBASE_SERVICE_ACCOUNT_BASE64" | base64 --decode > "$RUNNER_TEMP/firebase-service-account.json"
+          npm install -g firebase-tools
+          firebase appdistribution:distribute app/build/outputs/apk/debug/app-debug.apk --app "$FIREBASE_APP_ID" --groups "testers" --service-credentials "$RUNNER_TEMP/firebase-service-account.json"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.gradle/
+.idea/
+local.properties
+*.iml
+/build/
+/app/build/
+*.jks
+*.keystore
+firebase-service-account.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Jaafar Remote Android App
+
+A Kotlin + Jetpack Compose Android client that reads remotely managed configuration from the Render FastAPI backend.
+
+## Before building
+
+1. In `app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt`, replace `BACKEND_URL` with the public Render URL for the backend.
+2. The backend must expose `GET /api/v1/mobile/config` and return `{"message":"Hello from Telegram","enabled":true}`.
+3. Build locally with Android Studio or `gradle :app:assembleDebug`.
+
+## Firebase distribution
+
+The GitHub Action builds an APK on every push to `master` and keeps it as an Actions artifact. To distribute through Firebase App Distribution, add these GitHub repository secrets:
+
+- `FIREBASE_APP_ID`
+- `FIREBASE_SERVICE_ACCOUNT_BASE64` — base64 of a Firebase service-account JSON file with App Distribution access.
+
+Create the Firebase tester group named `testers`, or change the group in `.github/workflows/android.yml`.
+
+## Important
+
+Telegram should control content/configuration through the backend. It must never install arbitrary APKs or execute code received from Telegram. New app code should continue through a pull request, test, merge, and signed release pipeline.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+android {
+    namespace = "com.jaafar.remoteconfig"
+    compileSdk = 35
+    defaultConfig {
+        applicationId = "com.jaafar.remoteconfig"
+        minSdk = 24
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0.0"
+    }
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+    buildFeatures { compose = true }
+}
+dependencies {
+    implementation(platform("androidx.compose:compose-bom:2024.12.01"))
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+    implementation("androidx.activity:activity-compose:1.10.0")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add shrinking rules here when release minification is enabled.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.INTERNET" />
+  <application android:allowBackup="true" android:label="@string/app_name" android:theme="@style/Theme.RemoteConfig">
+    <activity android:name=".MainActivity" android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
@@ -1,0 +1,51 @@
+package com.jaafar.remoteconfig
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+private const val BACKEND_URL = "https://YOUR-RENDER-SERVICE.onrender.com"
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            var message by remember { mutableStateOf("Loading remote configuration…") }
+            var enabled by remember { mutableStateOf(true) }
+            var loading by remember { mutableStateOf(false) }
+            val repository = remember { RemoteConfigRepository(BACKEND_URL) }
+            fun refresh() {
+                loading = true
+                repository.fetch { result ->
+                    runOnUiThread {
+                        result.onSuccess { config -> message = config.message; enabled = config.enabled }
+                            .onFailure { message = "Could not load configuration. Check the backend URL." }
+                        loading = false
+                    }
+                }
+            }
+            MaterialTheme {
+                Column(modifier = Modifier.fillMaxSize().padding(24.dp), verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(if (enabled) message else "This feature is currently disabled.", style = MaterialTheme.typography.headlineSmall)
+                    Button(onClick = ::refresh, enabled = !loading, modifier = Modifier.padding(top = 20.dp)) {
+                        Text(if (loading) "Refreshing…" else "Refresh configuration")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
-private const val BACKEND_URL = "https://YOUR-RENDER-SERVICE.onrender.com"
+private const val BACKEND_URL = "https://jaafar-agents.onrender.com"
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/jaafar/remoteconfig/RemoteConfigRepository.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/RemoteConfigRepository.kt
@@ -1,0 +1,25 @@
+package com.jaafar.remoteconfig
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.io.IOException
+
+data class RemoteConfig(val message: String, val enabled: Boolean)
+
+class RemoteConfigRepository(private val baseUrl: String) {
+    private val client = OkHttpClient()
+    fun fetch(callback: (Result<RemoteConfig>) -> Unit) {
+        val request = Request.Builder().url("$baseUrl/api/v1/mobile/config").get().build()
+        client.newCall(request).enqueue(object : okhttp3.Callback {
+            override fun onFailure(call: okhttp3.Call, e: IOException) = callback(Result.failure(e))
+            override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                response.use {
+                    if (!it.isSuccessful) return callback(Result.failure(IOException("HTTP ${it.code}")))
+                    val json = JSONObject(it.body.string())
+                    callback(Result.success(RemoteConfig(json.optString("message", "Welcome"), json.optBoolean("enabled", true))))
+                }
+            }
+        })
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,1 @@
+<resources><string name="app_name">Jaafar Remote App</string></resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,1 @@
+<resources><style name="Theme.RemoteConfig" parent="android:style/Theme.Material.Light.NoActionBar" /></resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,4 @@
+pluginManagement { repositories { google(); mavenCentral(); gradlePluginPortal() } }
+dependencyResolutionManagement { repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS); repositories { google(); mavenCentral() } }
+rootProject.name = "JaafarOpenAi"
+include(":app")


### PR DESCRIPTION
## What changed

- Adds a Kotlin + Jetpack Compose Android application.
- Adds a small remote-configuration client for `GET /api/v1/mobile/config` on the Render backend.
- Adds a GitHub Actions workflow that builds an APK, uploads it as an artifact, and optionally distributes it through Firebase App Distribution.
- Adds setup documentation and excludes signing/service-account files from Git.

## Required after merge

1. Replace the placeholder Render URL in `MainActivity.kt`.
2. Implement the documented config endpoint in `Jaafar91/jaafar-agents`.
3. Add `FIREBASE_APP_ID` and `FIREBASE_SERVICE_ACCOUNT_BASE64` repository secrets.

## Safety

Telegram controls backend content/configuration only. Application code changes remain pull-request based; Telegram must not execute arbitrary code or install arbitrary APKs.

## Validation

The project structure and Gradle configuration were reviewed. An Android SDK/Gradle runtime was not available in this session, so the GitHub Actions workflow will perform the first hosted build after merge.