### PR TITLE
Fix Android APK workflow Gradle setup

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [master]
   workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,6 +16,8 @@ jobs:
           distribution: temurin
           java-version: "17"
       - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.10.2"
       - name: Build debug APK
         run: gradle :app:assembleDebug
       - name: Upload APK artifact


### PR DESCRIPTION
Fixes the failed APK workflow by installing pinned Gradle 8.10.2 before invoking `gradle :app:assembleDebug`. The repository does not yet include a Gradle wrapper, so the prior workflow had no `gradle` executable available.