### PR TITLE
Fix Android Java and Kotlin target mismatch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,9 +3,11 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
 }
+
 android {
     namespace = "com.jaafar.remoteconfig"
     compileSdk = 35
+
     defaultConfig {
         applicationId = "com.jaafar.remoteconfig"
         minSdk = 24
@@ -13,14 +15,26 @@ android {
         versionCode = 1
         versionName = "1.0.0"
     }
+
     buildTypes {
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
     buildFeatures { compose = true }
 }
+
+kotlin {
+    jvmToolchain(17)
+}
+
 dependencies {
     implementation(platform("androidx.compose:compose-bom:2024.12.01"))
     implementation("androidx.core:core-ktx:1.15.0")


### PR DESCRIPTION
Configures Android Java compilation and Kotlin JVM toolchain to Java 17, matching the GitHub Actions JDK. This fixes the `compileDebugJavaWithJavac` (1.8) versus `compileDebugKotlin` (17) compatibility failure.