### PR TITLE
Handle empty remote configuration responses

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/RemoteConfigRepository.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/RemoteConfigRepository.kt
@@ -9,15 +9,22 @@ data class RemoteConfig(val message: String, val enabled: Boolean)
 
 class RemoteConfigRepository(private val baseUrl: String) {
     private val client = OkHttpClient()
+
     fun fetch(callback: (Result<RemoteConfig>) -> Unit) {
         val request = Request.Builder().url("$baseUrl/api/v1/mobile/config").get().build()
         client.newCall(request).enqueue(object : okhttp3.Callback {
             override fun onFailure(call: okhttp3.Call, e: IOException) = callback(Result.failure(e))
+
             override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
                 response.use {
                     if (!it.isSuccessful) return callback(Result.failure(IOException("HTTP ${it.code}")))
-                    val json = JSONObject(it.body.string())
-                    callback(Result.success(RemoteConfig(json.optString("message", "Welcome"), json.optBoolean("enabled", true))))
+                    val body = it.body
+                        ?: return callback(Result.failure(IOException("Empty response body")))
+                    val json = JSONObject(body.string())
+                    callback(Result.success(RemoteConfig(
+                        json.optString("message", "Welcome"),
+                        json.optBoolean("enabled", true)
+                    )))
                 }
             }
         })


### PR DESCRIPTION
Fixes the Kotlin compilation error by checking for a missing HTTP response body before parsing JSON. The app now reports an explicit error instead of attempting to parse a null response body.