### PR TITLE
Add calculator screen

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
@@ -5,10 +5,14 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -16,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 private const val BACKEND_URL = "https://jaafar-agents.onrender.com"
@@ -28,22 +33,173 @@ class MainActivity : ComponentActivity() {
             var enabled by remember { mutableStateOf(true) }
             var loading by remember { mutableStateOf(false) }
             val repository = remember { RemoteConfigRepository(BACKEND_URL) }
+
             fun refresh() {
                 loading = true
                 repository.fetch { result ->
                     runOnUiThread {
-                        result.onSuccess { config -> message = config.message; enabled = config.enabled }
-                            .onFailure { message = "Could not load configuration. Check the backend URL." }
+                        result.onSuccess { config ->
+                            message = config.message
+                            enabled = config.enabled
+                        }.onFailure {
+                            message = "Could not load configuration. Check the backend URL."
+                        }
                         loading = false
                     }
                 }
             }
+
             MaterialTheme {
-                Column(modifier = Modifier.fillMaxSize().padding(24.dp), verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(if (enabled) message else "This feature is currently disabled.", style = MaterialTheme.typography.headlineSmall)
-                    Button(onClick = ::refresh, enabled = !loading, modifier = Modifier.padding(top = 20.dp)) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = if (enabled) message else "This feature is currently disabled.",
+                        style = MaterialTheme.typography.headlineSmall,
+                        textAlign = TextAlign.Center,
+                    )
+
+                    Button(onClick = ::refresh, enabled = !loading) {
                         Text(if (loading) "Refreshing…" else "Refresh configuration")
                     }
+
+                    if (enabled) {
+                        Calculator()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Calculator() {
+    var display by remember { mutableStateOf("0") }
+    var storedValue by remember { mutableStateOf<Double?>(null) }
+    var pendingOperation by remember { mutableStateOf<String?>(null) }
+    var enteringNewNumber by remember { mutableStateOf(true) }
+
+    fun format(value: Double): String =
+        if (value % 1.0 == 0.0) value.toLong().toString() else value.toString()
+
+    fun applyOperation(operation: String) {
+        val currentValue = display.toDoubleOrNull() ?: return
+        val previousValue = storedValue
+        if (previousValue != null && pendingOperation != null) {
+            val result = when (pendingOperation) {
+                "+" -> previousValue + currentValue
+                "−" -> previousValue - currentValue
+                "×" -> previousValue * currentValue
+                "÷" -> if (currentValue == 0.0) null else previousValue / currentValue
+                else -> currentValue
+            }
+            if (result == null) {
+                display = "Error"
+                storedValue = null
+                pendingOperation = null
+                enteringNewNumber = true
+                return
+            }
+            display = format(result)
+            storedValue = result
+        } else {
+            storedValue = currentValue
+        }
+        pendingOperation = operation
+        enteringNewNumber = true
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = "Calculator",
+            style = MaterialTheme.typography.titleLarge,
+        )
+        Text(
+            text = display,
+            modifier = Modifier.fillMaxWidth(),
+            style = MaterialTheme.typography.displaySmall,
+            textAlign = TextAlign.End,
+        )
+
+        listOf(
+            listOf("C", "±", "%", "÷"),
+            listOf("7", "8", "9", "×"),
+            listOf("4", "5", "6", "−"),
+            listOf("1", "2", "3", "+"),
+            listOf("0", ".", "="),
+        ).forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                row.forEach { label ->
+                    val isOperation = label in setOf("÷", "×", "−", "+")
+                    val isPrimary = label == "="
+                    val modifier = Modifier.weight(if (label == "0") 2f else 1f)
+
+                    if (isPrimary) {
+                        Button(
+                            onClick = {
+                                val operation = pendingOperation
+                                if (operation != null) {
+                                    applyOperation(operation)
+                                    pendingOperation = null
+                                }
+                            },
+                            modifier = modifier,
+                        ) {
+                            Text(label)
+                        }
+                    } else {
+                        OutlinedButton(
+                            onClick = {
+                                when {
+                                    label == "C" -> {
+                                        display = "0"
+                                        storedValue = null
+                                        pendingOperation = null
+                                        enteringNewNumber = true
+                                    }
+                                    label == "±" -> {
+                                        display.toDoubleOrNull()?.let { display = format(-it) }
+                                    }
+                                    label == "%" -> {
+                                        display.toDoubleOrNull()?.let { display = format(it / 100) }
+                                    }
+                                    isOperation -> applyOperation(label)
+                                    label == "." -> {
+                                        if (enteringNewNumber || display == "Error") {
+                                            display = "0."
+                                            enteringNewNumber = false
+                                        } else if (!display.contains(".")) {
+                                            display += "."
+                                        }
+                                    }
+                                    else -> {
+                                        display = if (enteringNewNumber || display == "0" || display == "Error") {
+                                            label
+                                        } else {
+                                            display + label
+                                        }
+                                        enteringNewNumber = false
+                                    }
+                                }
+                            },
+                            modifier = modifier,
+                        ) {
+                            Text(label)
+                        }
+                    }
+                }
+                repeat(4 - row.size - if (row.contains("0")) 1 else 0) {
+                    Row(modifier = Modifier.weight(1f)) {}
                 }
             }
         }

--- a/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
@@ -9,11 +9,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -142,7 +142,7 @@ private fun Calculator() {
                 row.forEach { label ->
                     val isOperation = label in setOf("÷", "×", "−", "+")
                     val isPrimary = label == "="
-                    val modifier = Modifier.weight(if (label == "0") 2f else 1f)
+                    val modifier = Modifier.padding(vertical = 2.dp)
 
                     if (isPrimary) {
                         Button(
@@ -197,9 +197,6 @@ private fun Calculator() {
                             Text(label)
                         }
                     }
-                }
-                repeat(4 - row.size - if (row.contains("0")) 1 else 0) {
-                    Row(modifier = Modifier.weight(1f)) {}
                 }
             }
         }


### PR DESCRIPTION
Closes #7

Adds a calculator beneath the remotely managed app message. It supports digits, decimals, sign change, percent, clear, addition, subtraction, multiplication, division, and division-by-zero handling. The calculator is hidden when remote configuration disables the app feature.

Validation: Android GitHub Actions build requested on this pull request.