### PR TITLE
Keep OpenAI and Copilot Telegram workflows separate

### DIFF
--- a/.github/workflows/telegram-feature-pr.yml
+++ b/.github/workflows/telegram-feature-pr.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   create-pr:
-    if: startsWith(github.event.issue.title, 'Telegram feature:')
+    if: startsWith(github.event.issue.title, 'Telegram OpenAI feature:')
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
Makes the existing OpenAI GitHub Action run only for issues created with `/openai` or `/feature`.

Issues created through `/copilot` are assigned directly to GitHub Copilot and will not also trigger the OpenAI action.