### PR TITLE
Build APKs for Copilot and Codex branches

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,7 +1,11 @@
 name: Android APK and Firebase distribution
+
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - 'copilot/**'
+      - 'codex/**'
   workflow_dispatch:
 
 jobs:
@@ -9,9 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-      FIREBASE_SERVICE_ACCOUNT_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -28,9 +29,28 @@ jobs:
         with:
           name: app-debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
+
+  distribute-to-firebase:
+    name: Distribute master APK to Firebase
+    needs: build
+    if: >-
+      github.ref == 'refs/heads/master' &&
+      secrets.FIREBASE_APP_ID != '' &&
+      secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+      FIREBASE_SERVICE_ACCOUNT_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}
+    steps:
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-debug-apk
+          path: apk
       - name: Upload to Firebase App Distribution
-        if: ${{ github.event_name == 'push' && env.FIREBASE_APP_ID != '' && env.FIREBASE_SERVICE_ACCOUNT_BASE64 != '' }}
         run: |
           echo "$FIREBASE_SERVICE_ACCOUNT_BASE64" | base64 --decode > "$RUNNER_TEMP/firebase-service-account.json"
           npm install -g firebase-tools
-          firebase appdistribution:distribute app/build/outputs/apk/debug/app-debug.apk --app "$FIREBASE_APP_ID" --groups "testers" --service-credentials "$RUNNER_TEMP/firebase-service-account.json"
+          firebase appdistribution:distribute apk/app-debug.apk --app "$FIREBASE_APP_ID" --groups "testers" --service-credentials "$RUNNER_TEMP/firebase-service-account.json"


### PR DESCRIPTION
## What changed

- Build and upload `app-debug-apk` whenever Copilot or Codex pushes a feature branch.
- Keep Firebase distribution restricted to builds from `master`.

## Why

Copilot PRs use `copilot/**` branches, while the workflow previously ran only after a push to `master`. No build ran for a Copilot PR, so no APK artifact existed.

## Security

Firebase secrets are scoped to the master-only distribution job and are unavailable to agent-branch builds.

## Validation

- Verified the committed workflow contains the intended branch triggers and separate build/distribution jobs.