### PR TITLE
Build and download APKs through GitHub Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,10 +33,7 @@ jobs:
   distribute-to-firebase:
     name: Distribute master APK to Firebase
     needs: build
-    if: >-
-      github.ref == 'refs/heads/master' &&
-      secrets.FIREBASE_APP_ID != '' &&
-      secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 != ''
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -50,6 +47,7 @@ jobs:
           name: app-debug-apk
           path: apk
       - name: Upload to Firebase App Distribution
+        if: env.FIREBASE_APP_ID != '' && env.FIREBASE_SERVICE_ACCOUNT_BASE64 != ''
         run: |
           echo "$FIREBASE_SERVICE_ACCOUNT_BASE64" | base64 --decode > "$RUNNER_TEMP/firebase-service-account.json"
           npm install -g firebase-tools

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,4 @@
-name: Android APK and Firebase distribution
+name: Build Android APK
 
 on:
   push:
@@ -29,26 +29,3 @@ jobs:
         with:
           name: app-debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
-
-  distribute-to-firebase:
-    name: Distribute master APK to Firebase
-    needs: build
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-      FIREBASE_SERVICE_ACCOUNT_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}
-    steps:
-      - name: Download APK artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: app-debug-apk
-          path: apk
-      - name: Upload to Firebase App Distribution
-        if: env.FIREBASE_APP_ID != '' && env.FIREBASE_SERVICE_ACCOUNT_BASE64 != ''
-        run: |
-          echo "$FIREBASE_SERVICE_ACCOUNT_BASE64" | base64 --decode > "$RUNNER_TEMP/firebase-service-account.json"
-          npm install -g firebase-tools
-          firebase appdistribution:distribute apk/app-debug.apk --app "$FIREBASE_APP_ID" --groups "testers" --service-credentials "$RUNNER_TEMP/firebase-service-account.json"


### PR DESCRIPTION
## What changed

- Removes Firebase App Distribution entirely.
- Builds a debug APK and uploads it as the `app-debug-apk` artifact.
- Runs automatically for `master`, `copilot/**`, and `codex/**` branch pushes.

## Why

GitHub Actions artifacts are the only APK distribution method needed. This also removes the invalid Firebase condition that prevented recent builds from starting.

## Result

After a successful run, download the APK from the run's **Artifacts** section in GitHub Actions.