### PR TITLE
Focus document workflow and improve Fill & Mark usability

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -211,19 +211,24 @@ private fun FillMarkLandingScreen(
     }
 
     Page("Fill & Mark Document", back) {
+        Text("Prepare a document", style = MaterialTheme.typography.headlineSmall)
         Text(
-            "Open a PDF or image and add visual marks: text, date, check, signature, or stamp. " +
-                "This is visual document marking — it does not create a certified digital signature " +
-                "or preserve editable PDF form fields.",
-            style = MaterialTheme.typography.bodySmall,
+            "Open a PDF or image, then add text, dates, checks, signatures, or stamps.",
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Button(
             onClick = { picker.launch(arrayOf("application/pdf", "image/*")) },
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Text("Open document\u2026")
+            Text("Choose a PDF or image")
         }
+
+        Text(
+            "Visual marks are added to the exported copy.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
 
         if (recentDocs.isNotEmpty()) {
             HorizontalDivider()
@@ -506,6 +511,11 @@ private fun FillMarkEditorScreen(
 
                 // Per-tool configuration panel
                 if (activeTool != null) {
+                    Text(
+                        "Tap on the document to place a ${activeTool!!.label.lowercase()}.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
                     MarkConfigPanel(
                         tool = activeTool!!,
                         configText = configText,
@@ -628,6 +638,14 @@ private fun FillMarkEditorScreen(
             }
 
             // ── FIXED BOTTOM (export status) ─────────────────────────────────────
+            if (marks.isNotEmpty() && !isProcessing) {
+                Button(
+                    onClick = ::triggerExport,
+                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                ) {
+                    Text("Export & Share")
+                }
+            }
             if (isProcessing) LinearProgressIndicator(Modifier.fillMaxWidth())
             if (status.isNotBlank()) Text(
                 status,

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -289,7 +290,7 @@ private fun FillMarkEditorScreen(
     var configText by remember { mutableStateOf(initialText ?: "") }
     var configColorIdx by remember { mutableIntStateOf(0) }
     var configFontIdx by remember { mutableIntStateOf(-1) }
-    var configSizeFraction by remember { mutableFloatStateOf(0.15f) }
+    var configSizeFraction by remember { mutableFloatStateOf(0.20f) }
     var configCheckStyle by remember { mutableStateOf(CheckStyle.Check) }
     var configSignatureName by remember { mutableStateOf<String?>(null) }
     var configApplyToAll by remember { mutableStateOf(false) }
@@ -332,18 +333,18 @@ private fun FillMarkEditorScreen(
         onDispose { sigBitmapCache.values.forEach { it.recycle() } }
     }
 
-    // Load document
-    LaunchedEffect(documentUri) {
+    // One effect owns document loading and PDF-page changes, avoiding a first-load race.
+    LaunchedEffect(documentUri, currentPage) {
         val mimeType = withContext(Dispatchers.IO) { context.contentResolver.getType(documentUri) }
         val looksLikePdf = withContext(Dispatchers.IO) {
             displayNameForUri(context, documentUri)?.endsWith(".pdf", true) == true
         }
         if (mimeType == "application/pdf" || looksLikePdf) {
             val count = withContext(Dispatchers.IO) { getPdfPageCount(context, documentUri) }
-            val bmp = withContext(Dispatchers.IO) { renderPdfPage(context, documentUri, 0) }
             isPdf = true
             pageCount = count
-            currentPage = 0
+            val safePage = currentPage.coerceIn(0, (count - 1).coerceAtLeast(0))
+            val bmp = withContext(Dispatchers.IO) { renderPdfPage(context, documentUri, safePage) }
             previewBitmap = bmp
         } else {
             val bmp = withContext(Dispatchers.IO) { loadBitmap(context.contentResolver, documentUri) }
@@ -351,13 +352,6 @@ private fun FillMarkEditorScreen(
             pageCount = 0
             previewBitmap = bmp
         }
-    }
-
-    // Reload PDF page when page changes
-    LaunchedEffect(currentPage) {
-        if (!isPdf) return@LaunchedEffect
-        val bmp = withContext(Dispatchers.IO) { renderPdfPage(context, documentUri, currentPage) }
-        previewBitmap = bmp
     }
 
     // Sync selected-mark config into edit fields whenever selection changes
@@ -566,11 +560,13 @@ private fun FillMarkEditorScreen(
                 Modifier
                     .fillMaxWidth()
                     .weight(1f)
+                    .heightIn(min = 200.dp)
                     .verticalScroll(rememberScrollState()),
             ) {
                 val bitmap = previewBitmap
                 if (bitmap != null) {
                     val previewAspect = bitmap.width.toFloat() / bitmap.height.toFloat()
+                    val visibleMarks = marks.filter { it.applyToAllPages || it.targetPage == currentPage }
                     Box(
                         Modifier
                             .fillMaxWidth()
@@ -587,11 +583,11 @@ private fun FillMarkEditorScreen(
                         Canvas(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .pointerInput(activeTool) {
+                                .pointerInput(activeTool, currentPage) {
                                     detectTapGestures { offset ->
                                         val w = canvasDisplaySize.width.toFloat().coerceAtLeast(1f)
                                         val h = canvasDisplaySize.height.toFloat().coerceAtLeast(1f)
-                                        val hit = marks.lastOrNull { mark ->
+                                        val hit = visibleMarks.lastOrNull { mark ->
                                             markContainsPoint(mark, offset, w, h)
                                         }
                                         when {
@@ -623,7 +619,7 @@ private fun FillMarkEditorScreen(
                         ) {
                             val w = size.width
                             val h = size.height
-                            marks.forEach { mark ->
+                            visibleMarks.forEach { mark ->
                                 val isSelected = mark.id == selectedMarkId
                                 drawMarkOnCanvas(mark, w, h, isSelected, fontOptions, sigBitmapCache)
                             }
@@ -933,8 +929,8 @@ private fun markContainsPoint(mark: DocumentMark, point: androidx.compose.ui.geo
     val top = mark.offsetY * h
     val width = mark.sizeFraction * w
     val height = when (mark.type) {
-        MarkType.Text, MarkType.Date, MarkType.Check -> width * 0.3f
-        MarkType.Signature, MarkType.Stamp -> width * 0.5f
+        MarkType.Text, MarkType.Date, MarkType.Check -> width * 0.5f
+        MarkType.Signature, MarkType.Stamp -> width * 0.7f
     }
     return point.x in left..(left + width) && point.y in top..(top + height)
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -172,14 +172,34 @@ private fun appTypography(fontFamily: FontFamily?): Typography {
 @Composable private fun HomeScreen(vm: FontCreatorViewModel, go: (Screen) -> Unit) = Page("Home", scrollable = true, actions = {
     TextButton(onClick = { go(Screen.Settings) }) { Text("Settings") }
 }) {
-    Text("Choose an action", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
-    HomeButton("Fill & Mark Document", "Add text, date, check, signature, or stamp marks to a PDF or image") { go(Screen.FillMark) }
-    HomeButton("Create a Font", "Start or continue your generated font workflow") { go(Screen.Fonts) }
-    HomeButton("Add Text to an Image", "Use the existing write-on-image workflow") { go(Screen.Image) }
-    HomeButton("Change Text in a Document", "Use PDF Font Converter (includes OCR inside this flow)") { go(Screen.PdfFont) }
-    HomeButton("Sign or Stamp a Document", "Open your signature and stamp workflow for images and PDFs") { go(Screen.Signature) }
-    HomeButton("My Library", "Browse and manage your fonts and signatures") { go(Screen.Library) }
+    Text("What would you like to do?", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
+    Text(
+        "Start with your document, then add the text, signature, or stamp you need.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    PrimaryHomeButton(
+        "Fill & Mark Document",
+        "Open a PDF or image, add marks, then export or share it",
+    ) { go(Screen.FillMark) }
+
+    Text("Create & personalise", style = MaterialTheme.typography.titleSmall)
+    HomeButton("Create a Font", "Create, import, or continue a handwriting font") { go(Screen.Fonts) }
+    HomeButton("Add Text to an Image", "Place your saved font on an image") { go(Screen.Image) }
+    HomeButton("Convert Document Text", "Experimental: rebuild recognised document text using a font") { go(Screen.PdfFont) }
+
+    Text("Your assets", style = MaterialTheme.typography.titleSmall)
+    HomeButton("My Library", "Manage fonts, signatures, and stamps") { go(Screen.Library) }
     vm.activeProject?.let { Text("Open font: ${it.name}", style = MaterialTheme.typography.titleMedium) }
+}
+
+@Composable private fun PrimaryHomeButton(title: String, detail: String, click: () -> Unit) {
+    Button(onClick = click, modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+            Text(title, fontWeight = FontWeight.Bold)
+            Text(detail, style = MaterialTheme.typography.bodySmall)
+        }
+    }
 }
 
 @Composable private fun HomeButton(title: String, detail: String, enabled: Boolean = true, click: () -> Unit) {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignatureScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignatureScreen.kt
@@ -80,7 +80,8 @@ internal fun SignatureScreen(
     onQuickMark: (String) -> Unit = {},
     back: () -> Unit,
 ) {
-    var page by remember { mutableStateOf(SignaturePage.Apply) }
+    // The library is the asset-management destination. Applying a mark starts only after one is selected.
+    var page by remember { mutableStateOf(SignaturePage.Library) }
     var selectedSignatureName by remember { mutableStateOf<String?>(null) }
 
     when (page) {
@@ -92,7 +93,7 @@ internal fun SignatureScreen(
             onImportStamp = { page = SignaturePage.ImportStamp },
             onUseSelected = { page = SignaturePage.Apply },
             onQuickMark = onQuickMark,
-            back = { page = SignaturePage.Apply },
+            back = back,
         )
         SignaturePage.Editor -> SignatureEditorScreen(
             vm = vm,


### PR DESCRIPTION
## What changed

- Makes **Fill & Mark Document** the clear primary home action and removes the duplicate Sign or Stamp entry point.
- Groups remaining actions into **Create & personalise** and **Your assets**.
- Renames the PDF OCR action to **Convert Document Text** and labels it experimental.
- Opens **Signatures & Stamps** directly in its library instead of an empty apply screen.
- Simplifies the Fill & Mark opening text, adds an in-context placement instruction, and exposes a clear **Export & Share** button.
- Includes the unmerged Fill & Mark interaction fixes from PR #93:
  - PDF page changes load reliably.
  - Marks only appear and receive taps on their target page (or all pages when selected).
  - The document canvas retains a usable minimum height.
  - Newly placed marks have a more usable default size and hit area.

## Why

The app had several overlapping entry points and hid the most important workflow behind equal-weight buttons. The document editor also made placement difficult on multi-page PDFs.

## Validation

- Reviewed the affected Compose flows and retained existing document export, sharing, font, signature, and stamp paths.
- GitHub Actions should build the Android APK for this PR.