### PR TITLE
Simplify text marks and add stable APK release setup

### DIFF
--- a/.github/workflows/signed-release.yml
+++ b/.github/workflows/signed-release.yml
@@ -1,0 +1,46 @@
+name: Build Signed Release APK
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-release:
+    # The signing key is intentionally used only for trusted master builds.
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    env:
+      ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/release.jks
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.10.2"
+      - name: Validate signing configuration
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          test -n "$ANDROID_KEYSTORE_BASE64"
+          test -n "$ANDROID_KEYSTORE_PASSWORD"
+          test -n "$ANDROID_KEY_ALIAS"
+          test -n "$ANDROID_KEY_PASSWORD"
+      - name: Restore signing key
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$ANDROID_KEYSTORE_PATH"
+      - name: Build signed release APK
+        run: gradle :app:assembleRelease
+      - name: Upload signed APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/SIGNED_APK_SETUP.md
+++ b/SIGNED_APK_SETUP.md
@@ -1,0 +1,46 @@
+# Signed APK setup
+
+GitHub's normal pull-request artifact is a debug APK. It is intentionally not used as the long-lived installation channel.
+
+To install updates without Android's **package conflict** message, create one permanent signing key and configure the GitHub secrets below. Keep the key and passwords private. If they are lost, existing users cannot update to a differently signed APK.
+
+## 1. Create the signing key on your own computer
+
+Run this in PowerShell and choose strong passwords when prompted:
+
+```powershell
+keytool -genkeypair -v -keystore jaafar-release.jks -alias jaafar-release -keyalg RSA -keysize 2048 -validity 10000
+```
+
+Back up `jaafar-release.jks` securely. Never commit it or send it in a chat.
+
+## 2. Copy the keystore as Base64
+
+Run:
+
+```powershell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes(".\jaafar-release.jks")) | Set-Clipboard
+```
+
+## 3. Add GitHub repository secrets
+
+Open **Settings → Secrets and variables → Actions → New repository secret** in this repository and add:
+
+| Secret | Value |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | The value copied in step 2 |
+| `ANDROID_KEYSTORE_PASSWORD` | The keystore password |
+| `ANDROID_KEY_ALIAS` | `jaafar-release` (or the alias you chose) |
+| `ANDROID_KEY_PASSWORD` | The key password |
+
+## 4. Build the installable release
+
+After this pull request is merged:
+
+1. Open **Actions → Build Signed Release APK**.
+2. Choose **Run workflow** while the selected branch is `master`.
+3. Download the `app-release-apk` artifact.
+
+Uninstall the old debug app from the phone once, then install this signed release APK. Each later signed release APK from this workflow has the same signing identity and a higher version code, so Android installs it as an update and retains app data.
+
+The signing workflow runs only from `master`. Pull-request code does not receive the permanent signing key.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,16 +8,31 @@ android {
     namespace = "com.jaafar.remoteconfig"
     compileSdk = 35
 
+    val ciBuildNumber = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
+
     defaultConfig {
         applicationId = "com.jaafar.remoteconfig"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0.0"
+        versionCode = ciBuildNumber ?: 1
+        versionName = if (ciBuildNumber == null) "1.0.0" else "1.0.$ciBuildNumber"
+    }
+
+    signingConfigs {
+        create("release") {
+            val keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+            if (!keystorePath.isNullOrBlank()) {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -11,12 +11,15 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -95,6 +98,8 @@ internal enum class MarkType(val label: String) {
     Signature("Signature"),
     Stamp("Stamp"),
 }
+
+private enum class TextEntryMode { Text, QuickMark }
 
 internal enum class CheckStyle(val symbol: String) { Check("\u2713"), Cross("\u2717") }
 
@@ -299,6 +304,7 @@ private fun FillMarkEditorScreen(
     var configCheckStyle by remember { mutableStateOf(CheckStyle.Check) }
     var configSignatureName by remember { mutableStateOf<String?>(null) }
     var configApplyToAll by remember { mutableStateOf(false) }
+    var textEntryMode by remember { mutableStateOf(TextEntryMode.Text) }
 
     val textColors = remember {
         listOf(
@@ -456,29 +462,38 @@ private fun FillMarkEditorScreen(
                     if (selectedMark == null) "Add ${activeTool!!.label}" else "Edit ${activeTool!!.label}",
                     style = MaterialTheme.typography.titleLarge,
                 )
-                MarkConfigPanel(
-                    tool = activeTool!!,
-                    configText = configText,
-                    onConfigTextChange = { configText = it },
-                    configColorIdx = configColorIdx,
-                    onColorChange = { configColorIdx = it; updateSelectedMark() },
-                    textColors = textColors,
-                    configFontIdx = configFontIdx,
-                    onFontChange = { configFontIdx = it; updateSelectedMark() },
-                    fontOptions = fontOptions,
-                    configSizeFraction = configSizeFraction,
-                    onSizeChange = { configSizeFraction = it; updateSelectedMark() },
-                    configCheckStyle = configCheckStyle,
-                    onCheckStyleChange = { configCheckStyle = it; updateSelectedMark() },
-                    configSignatureName = configSignatureName,
-                    onSignatureChange = { configSignatureName = it; updateSelectedMark() },
-                    vm = vm,
-                    isPdf = isPdf,
-                    configApplyToAll = configApplyToAll,
-                    onApplyToAllChange = { configApplyToAll = it; updateSelectedMark() },
-                    selectedMark = selectedMark,
-                    onTextCommit = { updateSelectedMark() },
-                )
+                if (activeTool == MarkType.Text && selectedMark == null) {
+                    TextEntryPanel(
+                        mode = textEntryMode,
+                        onModeChange = { textEntryMode = it },
+                        text = configText,
+                        onTextChange = { configText = it },
+                    )
+                } else {
+                    MarkConfigPanel(
+                        tool = activeTool!!,
+                        configText = configText,
+                        onConfigTextChange = { configText = it },
+                        configColorIdx = configColorIdx,
+                        onColorChange = { configColorIdx = it; updateSelectedMark() },
+                        textColors = textColors,
+                        configFontIdx = configFontIdx,
+                        onFontChange = { configFontIdx = it; updateSelectedMark() },
+                        fontOptions = fontOptions,
+                        configSizeFraction = configSizeFraction,
+                        onSizeChange = { configSizeFraction = it; updateSelectedMark() },
+                        configCheckStyle = configCheckStyle,
+                        onCheckStyleChange = { configCheckStyle = it; updateSelectedMark() },
+                        configSignatureName = configSignatureName,
+                        onSignatureChange = { configSignatureName = it; updateSelectedMark() },
+                        vm = vm,
+                        isPdf = isPdf,
+                        configApplyToAll = configApplyToAll,
+                        onApplyToAllChange = { configApplyToAll = it; updateSelectedMark() },
+                        selectedMark = selectedMark,
+                        onTextCommit = { updateSelectedMark() },
+                    )
+                }
                 if (selectedMark != null) {
                     TextButton(onClick = {
                         marks.removeIf { it.id == selectedMarkId }
@@ -495,7 +510,11 @@ private fun FillMarkEditorScreen(
                     },
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text(if (selectedMark == null) "Place on document" else "Done")
+                    Text(
+                        if (activeTool == MarkType.Text && selectedMark == null) "Continue"
+                        else if (selectedMark == null) "Place on document"
+                        else "Done",
+                    )
                 }
             }
         }
@@ -555,7 +574,6 @@ private fun FillMarkEditorScreen(
                                         when {
                                             hit != null -> {
                                                 selectedMarkId = hit.id
-                                                showMarkOptions = true
                                             }
                                             activeTool != null -> {
                                                 val xFrac = (offset.x / w).coerceIn(0f, 0.85f)
@@ -587,6 +605,19 @@ private fun FillMarkEditorScreen(
                             visibleMarks.forEach { mark ->
                                 val isSelected = mark.id == selectedMarkId
                                 drawMarkOnCanvas(mark, w, h, isSelected, fontOptions, sigBitmapCache)
+                            }
+                        }
+                        if (selectedMark != null) {
+                            Row(
+                                Modifier.align(Alignment.TopEnd).padding(6.dp),
+                                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                            ) {
+                                TextButton(onClick = { showMarkOptions = true }) { Text("✎") }
+                                TextButton(onClick = {
+                                    marks.removeIf { it.id == selectedMarkId }
+                                    selectedMarkId = null
+                                    activeTool = null
+                                }) { Text("×") }
                             }
                         }
                     }
@@ -761,21 +792,6 @@ private fun MarkConfigPanel(
                         }
                     },
                 )
-                // Quick marks presets
-                Text("Quick marks", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Row(
-                    Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    QUICK_MARK_PRESETS.forEach { preset ->
-                        OutlinedButton(onClick = {
-                            onConfigTextChange(preset)
-                            onTextCommit()
-                        }) { Text(preset, style = MaterialTheme.typography.labelSmall) }
-                    }
-                }
                 TextMarkStyleControls(
                     configColorIdx, onColorChange, textColors,
                     configFontIdx, onFontChange, fontOptions,
@@ -843,17 +859,23 @@ private fun TextMarkStyleControls(
     sizeFraction: Float, onSizeChange: (Float) -> Unit,
 ) {
     Row(
-        Modifier
-            .fillMaxWidth()
-            .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        colors.forEachIndexed { idx, (name, _) ->
-            if (idx == colorIdx) {
-                Button(onClick = {}) { Text(name) }
-            } else {
-                OutlinedButton(onClick = { onColorChange(idx) }) { Text(name) }
-            }
+        Text("Colour", style = MaterialTheme.typography.labelMedium)
+        colors.forEachIndexed { idx, (_, argb) ->
+            Box(
+                Modifier
+                    .size(28.dp)
+                    .background(ComposeColor(argb), CircleShape)
+                    .border(
+                        width = if (idx == colorIdx) 3.dp else 1.dp,
+                        color = if (idx == colorIdx) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+                        shape = CircleShape,
+                    )
+                    .clickable { onColorChange(idx) },
+            )
         }
     }
     if (fontOptions.isNotEmpty()) {
@@ -945,6 +967,41 @@ private fun SignatureStampSelector(
                         signature = sig,
                     )
                     Text(sig.name, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TextEntryPanel(
+    mode: TextEntryMode,
+    onModeChange: (TextEntryMode) -> Unit,
+    text: String,
+    onTextChange: (String) -> Unit,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        RadioButton(selected = mode == TextEntryMode.Text, onClick = { onModeChange(TextEntryMode.Text) })
+        Text("Text", modifier = Modifier.clickable { onModeChange(TextEntryMode.Text) })
+        RadioButton(selected = mode == TextEntryMode.QuickMark, onClick = { onModeChange(TextEntryMode.QuickMark) })
+        Text("Quick mark", modifier = Modifier.clickable { onModeChange(TextEntryMode.QuickMark) })
+    }
+    if (mode == TextEntryMode.Text) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = onTextChange,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("Type text to add") },
+            singleLine = true,
+        )
+    } else {
+        Row(
+            Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            QUICK_MARK_PRESETS.forEach { preset ->
+                OutlinedButton(onClick = { onTextChange(preset) }) {
+                    Text(preset, style = MaterialTheme.typography.labelSmall)
                 }
             }
         }


### PR DESCRIPTION
## Text mark flow

- New text marks now open a compact Text / Quick mark choice, defaulting to Text.
- The initial sheet shows only the text field or quick-mark presets; font, size, and colour are no longer shown before placement.
- Tapping a placed mark shows a selection border with edit and delete icons.
- The edit sheet holds advanced text styling. Colour is now selected with visible colour dots.

## APK update setup

- Adds a trusted master-only signed release workflow.
- Adds incrementing CI version codes for release builds.
- Documents the one-time GitHub Secrets setup in `SIGNED_APK_SETUP.md`.

The permanent signing key is deliberately not exposed to automatic pull-request code. PR artifacts remain test builds; after the documented setup, signed master release APKs update each other normally.

## Validation

GitHub Actions will compile the normal PR APK. The signed-release workflow is manually run from master after the signing secrets are configured.