### PR TITLE
Explain PDF errors and modernize app navigation

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -203,10 +203,45 @@ fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable internal fun AppTopBar(title: String, back: (() -> Unit)? = null, actions: @Composable RowScope.() -> Unit = {}) {
-    CenterAlignedTopAppBar(
-        title = { Text(title) },
-        navigationIcon = { if (back != null) IconButton(onClick = back) { BackIcon() } },
+    TopAppBar(
+        title = {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text("Aa", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
+                    }
+                }
+                Column {
+                    Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                    Text("FONT & MARK STUDIO", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        },
+        navigationIcon = {
+            if (back != null) {
+                IconButton(onClick = back) {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        shape = RoundedCornerShape(12.dp),
+                        modifier = Modifier.size(40.dp),
+                    ) {
+                        Box(contentAlignment = Alignment.Center) { BackIcon() }
+                    }
+                }
+            }
+        },
         actions = actions,
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.background,
+            titleContentColor = MaterialTheme.colorScheme.onBackground,
+            actionIconContentColor = MaterialTheme.colorScheme.primary,
+        ),
     )
 }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/PdfFontScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/PdfFontScreen.kt
@@ -189,14 +189,14 @@ internal fun PdfFontScreen(vm: FontCreatorViewModel, back: () -> Unit) {
                     scope.launch {
                         val result = rebuildPdf(context, uri, document, selectedTypeface)
                         isProcessing = false
-                        if (result != null) {
-                            outputFile = result
-                            status = "Restyled PDF created. Your original is unchanged."
-                            isError = false
-                        } else {
-                            status = "Failed to generate the PDF."
+                        val file = result.getOrElse { error ->
+                            status = restyleFailureMessage(error)
                             isError = true
+                            return@launch
                         }
+                        outputFile = file
+                        status = "Restyled PDF created. Your original is unchanged."
+                        isError = false
                     }
                 },
                 enabled = recognizedDocument != null && !isProcessing,
@@ -335,7 +335,7 @@ private suspend fun rebuildPdf(
     sourceUri: Uri,
     document: RecognizedDocument,
     typeface: Typeface
-): File? = withContext(Dispatchers.IO) {
+): Result<File> = withContext(Dispatchers.IO) {
     runCatching {
         val outputDoc = PdfDocument()
         val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
@@ -381,7 +381,13 @@ private suspend fun rebuildPdf(
         FileOutputStream(outputFile).use { outputDoc.writeTo(it) }
         outputDoc.close()
         outputFile
-    }.getOrNull()
+    }
+}
+
+private fun restyleFailureMessage(error: Throwable): String = when (error) {
+    is SecurityException -> "The document can no longer be accessed. Choose it again and retry."
+    is OutOfMemoryError -> "This document is too large to process on this device. Try a smaller file or fewer pages."
+    else -> "Could not create the restyled PDF: ${error.message?.take(120) ?: "an unexpected error occurred"}"
 }
 
 private fun loadSourcePageBitmap(context: android.content.Context, sourceUri: Uri, pageIndex: Int): Bitmap? {


### PR DESCRIPTION
## What changed

- Restyled-PDF generation now keeps its error result instead of silently turning every failure into a generic message.
- Gives customers a practical reason, including lost file access, a document that is too large, or the actual underlying PDF error.
- Replaced the plain centred top bar with a shared modern studio header: font mark, clearer title hierarchy, rounded back control, and theme-aware colours.

## Why

The previous conversion screen hid the cause of failures, making it impossible for a customer to know what to change. The shared header also made every screen look like a basic utility view rather than one coherent app.

## Validation

- Reviewed the focused two-file change.
- The pull-request Android workflow will provide the compilation and test-APK check.