### PR TITLE
Simplify document text placement and restore page titles

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -99,8 +99,6 @@ internal enum class MarkType(val label: String) {
     Stamp("Stamp"),
 }
 
-private enum class TextEntryMode { Text, QuickMark }
-
 internal enum class CheckStyle(val symbol: String) { Check("\u2713"), Cross("\u2717") }
 
 internal data class DocumentMark(
@@ -292,7 +290,9 @@ private fun FillMarkEditorScreen(
     var configCheckStyle by remember { mutableStateOf(CheckStyle.Check) }
     var configSignatureName by remember { mutableStateOf<String?>(null) }
     var configApplyToAll by remember { mutableStateOf(false) }
-    var textEntryMode by remember { mutableStateOf(TextEntryMode.Text) }
+    var pendingTextPosition by remember { mutableStateOf<Offset?>(null) }
+    var showTextEntry by remember { mutableStateOf(false) }
+    var showQuickMarks by remember { mutableStateOf(false) }
 
     val textColors = remember {
         listOf(
@@ -363,7 +363,6 @@ private fun FillMarkEditorScreen(
     // Sync selected-mark config into edit fields whenever selection changes
     LaunchedEffect(selectedMarkId) {
         val m = marks.firstOrNull { it.id == selectedMarkId } ?: return@LaunchedEffect
-        activeTool = m.type
         configText = m.text
         configColorIdx = textColors.indexOfFirst { it.second == m.colorArgb }.takeIf { it >= 0 } ?: 0
         configFontIdx = fontOptions.indexOfFirst { it.first == m.fontKey }.takeIf { it >= 0 } ?: -1
@@ -395,8 +394,7 @@ private fun FillMarkEditorScreen(
             targetPage = currentPage,
         )
         marks.add(newMark)
-        // A mark is placed in one deliberate action; tap it again later to edit it.
-        selectedMarkId = null
+        selectedMarkId = newMark.id
         activeTool = null
     }
 
@@ -444,6 +442,38 @@ private fun FillMarkEditorScreen(
         }
     }
 
+    if (showQuickMarks) {
+        ModalBottomSheet(onDismissRequest = { showQuickMarks = false }) {
+            Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text("Quick mark", style = MaterialTheme.typography.titleLarge)
+                Text("Choose a label, then tap where it belongs.", style = MaterialTheme.typography.bodyMedium)
+                QUICK_MARK_PRESETS.forEach { preset ->
+                    OutlinedButton(onClick = { configText = preset; activeTool = MarkType.Text; selectedMarkId = null; showQuickMarks = false }, modifier = Modifier.fillMaxWidth()) { Text(preset) }
+                }
+            }
+        }
+    }
+
+    if (showTextEntry && pendingTextPosition != null) {
+        ModalBottomSheet(onDismissRequest = { showTextEntry = false; pendingTextPosition = null }) {
+            Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(value = configText, onValueChange = { configText = it }, modifier = Modifier.fillMaxWidth(), placeholder = { Text("Type text") }, singleLine = true)
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    TextButton(onClick = { showTextEntry = false; pendingTextPosition = null }, modifier = Modifier.weight(1f)) { Text("Cancel") }
+                    Button(onClick = {
+                        val position = pendingTextPosition ?: return@Button
+                        val newMark = DocumentMark(type = MarkType.Text, offsetX = position.x, offsetY = position.y, sizeFraction = configSizeFraction, text = configText.ifBlank { "Text" }, colorArgb = textColors.getOrNull(configColorIdx)?.second ?: Color.BLACK, fontKey = fontOptions.getOrNull(configFontIdx)?.first, targetPage = currentPage)
+                        marks.add(newMark)
+                        selectedMarkId = newMark.id
+                        activeTool = null
+                        showTextEntry = false
+                        pendingTextPosition = null
+                    }, modifier = Modifier.weight(1f)) { Text("Add text") }
+                }
+            }
+        }
+    }
+
     if (showMarkOptions && activeTool != null) {
         ModalBottomSheet(onDismissRequest = { showMarkOptions = false }) {
             Column(
@@ -457,15 +487,7 @@ private fun FillMarkEditorScreen(
                     if (selectedMark == null) "Add ${activeTool!!.label}" else "Edit ${activeTool!!.label}",
                     style = MaterialTheme.typography.titleLarge,
                 )
-                if (activeTool == MarkType.Text && selectedMark == null) {
-                    TextEntryPanel(
-                        mode = textEntryMode,
-                        onModeChange = { textEntryMode = it },
-                        text = configText,
-                        onTextChange = { configText = it },
-                    )
-                } else {
-                    MarkConfigPanel(
+                MarkConfigPanel(
                         tool = activeTool!!,
                         configText = configText,
                         onConfigTextChange = { configText = it },
@@ -488,7 +510,6 @@ private fun FillMarkEditorScreen(
                         selectedMark = selectedMark,
                         onTextCommit = { updateSelectedMark() },
                     )
-                }
                 if (selectedMark != null) {
                     TextButton(onClick = {
                         marks.removeIf { it.id == selectedMarkId }
@@ -506,9 +527,7 @@ private fun FillMarkEditorScreen(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(
-                        if (activeTool == MarkType.Text && selectedMark == null) "Continue"
-                        else if (selectedMark == null) "Place on document"
-                        else "Done",
+                        if (selectedMark == null) "Place on document" else "Done",
                     )
                 }
             }
@@ -573,7 +592,13 @@ private fun FillMarkEditorScreen(
                                             activeTool != null -> {
                                                 val xFrac = (offset.x / w).coerceIn(0f, 0.85f)
                                                 val yFrac = (offset.y / h).coerceIn(0f, 0.85f)
-                                                addOrUpdateMark(xFrac, yFrac)
+                                                if (activeTool == MarkType.Text) {
+                                                    pendingTextPosition = Offset(xFrac, yFrac)
+                                                    activeTool = null
+                                                    showTextEntry = true
+                                                } else {
+                                                    addOrUpdateMark(xFrac, yFrac)
+                                                }
                                             }
                                             else -> selectedMarkId = null
                                         }
@@ -600,19 +625,6 @@ private fun FillMarkEditorScreen(
                             visibleMarks.forEach { mark ->
                                 val isSelected = mark.id == selectedMarkId
                                 drawMarkOnCanvas(mark, w, h, isSelected, fontOptions, sigBitmapCache)
-                            }
-                        }
-                        if (selectedMark != null) {
-                            Row(
-                                Modifier.align(Alignment.TopEnd).padding(6.dp),
-                                horizontalArrangement = Arrangement.spacedBy(2.dp),
-                            ) {
-                                TextButton(onClick = { showMarkOptions = true }) { Text("✎") }
-                                TextButton(onClick = {
-                                    marks.removeIf { it.id == selectedMarkId }
-                                    selectedMarkId = null
-                                    activeTool = null
-                                }) { Text("×") }
                             }
                         }
                     }
@@ -662,17 +674,25 @@ private fun FillMarkEditorScreen(
                         .horizontalScroll(rememberScrollState()),
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
-                    availableTools.forEach { tool ->
+                    val isTextMode = activeTool == MarkType.Text
+                    OutlinedButton(onClick = {
+                        activeTool = if (isTextMode) null else MarkType.Text
+                        configText = ""
+                        selectedMarkId = null
+                        showMarkOptions = false
+                    }) { Text("Text") }
+                    TextButton(onClick = { activeTool = null; selectedMarkId = null; showQuickMarks = true }) { Text("Quick") }
+                    availableTools.filter { it != MarkType.Text }.forEach { tool ->
                         val compactLabel = when (tool) {
-                            MarkType.Text -> "Text"
                             MarkType.Date -> "Date"
                             MarkType.Check -> "✓"
                             MarkType.Signature -> "Sign"
                             MarkType.Stamp -> "Stamp"
+                            MarkType.Text -> error("Text is handled above")
                         }
                         val isActive = activeTool == tool
                         if (isActive) {
-                            Button(onClick = { activeTool = null; selectedMarkId = null }) { Text(compactLabel) }
+                            OutlinedButton(onClick = { activeTool = null; selectedMarkId = null }) { Text(compactLabel) }
                         } else {
                             TextButton(onClick = {
                                 activeTool = tool
@@ -694,6 +714,12 @@ private fun FillMarkEditorScreen(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.primary,
                     )
+                }
+                if (selectedMark != null) {
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(onClick = { activeTool = selectedMark.type; showMarkOptions = true }, modifier = Modifier.weight(1f)) { Text("Edit") }
+                        TextButton(onClick = { marks.removeIf { it.id == selectedMarkId }; selectedMarkId = null; activeTool = null }, modifier = Modifier.weight(1f)) { Text("Delete") }
+                    }
                 }
 
                 HorizontalDivider()
@@ -967,41 +993,6 @@ private fun SignatureStampSelector(
                         signature = sig,
                     )
                     Text(sig.name, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodySmall)
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun TextEntryPanel(
-    mode: TextEntryMode,
-    onModeChange: (TextEntryMode) -> Unit,
-    text: String,
-    onTextChange: (String) -> Unit,
-) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        RadioButton(selected = mode == TextEntryMode.Text, onClick = { onModeChange(TextEntryMode.Text) })
-        Text("Text", modifier = Modifier.clickable { onModeChange(TextEntryMode.Text) })
-        RadioButton(selected = mode == TextEntryMode.QuickMark, onClick = { onModeChange(TextEntryMode.QuickMark) })
-        Text("Quick mark", modifier = Modifier.clickable { onModeChange(TextEntryMode.QuickMark) })
-    }
-    if (mode == TextEntryMode.Text) {
-        OutlinedTextField(
-            value = text,
-            onValueChange = onTextChange,
-            modifier = Modifier.fillMaxWidth(),
-            placeholder = { Text("Type text to add") },
-            singleLine = true,
-        )
-    } else {
-        Row(
-            Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            QUICK_MARK_PRESETS.forEach { preset ->
-                OutlinedButton(onClick = { onTextChange(preset) }) {
-                    Text(preset, style = MaterialTheme.typography.labelSmall)
                 }
             }
         }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -216,7 +216,7 @@ fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
                         Text("Aa", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
                     }
                 }
-                Text("Font Creator", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Text(if (title == "Studio") "Font Creator" else title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
             }
         },
         navigationIcon = {


### PR DESCRIPTION
## What changed
- Keeps **Font Creator** on the Home screen only; every other screen shows its own title.
- Changes Text to a location-first flow: choose Text → tap the document → type the text.
- Moves Quick marks into their own picker.
- Keeps a newly added mark selected and adds clear Edit and Delete controls beneath the document.

## Test plan
- GitHub Actions should build the PR APK automatically.