### PR TITLE
Build a signed Play Store app bundle

### DIFF
--- a/.github/workflows/signed-release.yml
+++ b/.github/workflows/signed-release.yml
@@ -1,4 +1,4 @@
-name: Build Signed Release APK
+name: Build Signed Play Release
 
 on:
   workflow_dispatch:
@@ -37,9 +37,14 @@ jobs:
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$ANDROID_KEYSTORE_PATH"
-      - name: Build signed release APK
-        run: gradle :app:assembleRelease
-      - name: Upload signed APK
+      - name: Build signed release bundle and APK
+        run: gradle :app:bundleRelease :app:assembleRelease
+      - name: Upload Play Store bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-aab
+          path: app/build/outputs/bundle/release/app-release.aab
+      - name: Upload signed APK for direct installation
         uses: actions/upload-artifact@v4
         with:
           name: app-release-apk

--- a/SIGNED_APK_SETUP.md
+++ b/SIGNED_APK_SETUP.md
@@ -1,4 +1,4 @@
-# Signed APK setup
+# Play Store signing setup
 
 GitHub's normal pull-request artifact is a debug APK. It is intentionally not used as the long-lived installation channel.
 
@@ -33,14 +33,14 @@ Open **Settings → Secrets and variables → Actions → New repository secret*
 | `ANDROID_KEY_ALIAS` | `jaafar-release` (or the alias you chose) |
 | `ANDROID_KEY_PASSWORD` | The key password |
 
-## 4. Build the installable release
+## 4. Build the Play Store release
 
 After this pull request is merged:
 
-1. Open **Actions → Build Signed Release APK**.
+1. Open **Actions → Build Signed Play Release**.
 2. Choose **Run workflow** while the selected branch is `master`.
-3. Download the `app-release-apk` artifact.
+3. Download `app-release-aab` to upload to Google Play.\n4. Download `app-release-apk` only when you need to install a direct test build on your own phone.
 
-Uninstall the old debug app from the phone once, then install this signed release APK. Each later signed release APK from this workflow has the same signing identity and a higher version code, so Android installs it as an update and retains app data.
+For Google Play, upload the `.aab` artifact and enable Play App Signing during the first release. The `.apk` artifact is for direct device testing only. Uninstall the old debug app once before installing the signed APK. Each later signed release APK has the same signing identity and a higher version code, so Android installs it as an update and retains app data.
 
 The signing workflow runs only from `master`. Pull-request code does not receive the permanent signing key.


### PR DESCRIPTION
## First Play Store readiness step
- Builds a signed `.aab` using the existing keystore secrets.
- Keeps the signed APK artifact for direct phone testing.
- Updates the signing guide with the Play Store upload flow and Play App Signing note.

No new secret is required. After merge, run **Build Signed Play Release** on master and upload the `app-release-aab` artifact to Play Console.