### PR TITLE
Use a unique Font Creator package ID

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     val ciBuildNumber = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
 
     defaultConfig {
-        applicationId = "com.jaafar.remoteconfig"
+        applicationId = "io.github.jaafar91.fontcreator"
         minSdk = 24
         targetSdk = 35
         versionCode = ciBuildNumber ?: 1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     val ciBuildNumber = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
 
     defaultConfig {
-        applicationId = "io.github.jaafar91.fontcreator"
+        applicationId = "com.mjaafar.fontcreator"
         minSdk = 24
         targetSdk = 35
         versionCode = ciBuildNumber ?: 1


### PR DESCRIPTION
Changes the Play Store application ID from the old generic remote-config identifier to:

`io.github.jaafar91.fontcreator`

This ID is unique to the GitHub owner and matches Font Creator. Merge this before creating the Play Console app record or uploading the first bundle.