### PR TITLE
Automate PR builds to internal testing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,28 +1,63 @@
-name: Build Android APK
+name: Build and distribute internal test
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  build:
+  build-and-distribute:
     runs-on: ubuntu-latest
+    env:
+      # The release is published only when all signing and Play credentials exist.
+      # Fork pull requests never receive repository secrets, so they remain build-only.
+      PLAY_PUBLISH_ENABLED: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && secrets.ANDROID_KEYSTORE_PASSWORD != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "17"
+
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: "8.10.2"
-      - name: Build debug APK
-        run: gradle :app:assembleDebug
-      - name: Upload APK artifact
+
+      - name: Verify the app
+        run: gradle :app:testDebugUnitTest
+
+      - name: Restore release keystore
+        if: env.PLAY_PUBLISH_ENABLED == 'true'
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
+
+      - name: Build release app bundle
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: gradle :app:bundleRelease
+
+      - name: Upload app bundle artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug-apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          name: font-creator-pr-${{ github.event.pull_request.number || github.run_number }}-aab
+          path: app/build/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
+
+      - name: Upload to Google Play internal testing
+        if: env.PLAY_PUBLISH_ENABLED == 'true'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.mjaafar.fontcreator
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,6 +30,16 @@ jobs:
       - name: Verify the app
         run: gradle :app:testDebugUnitTest
 
+      - name: Build debug APK
+        run: gradle :app:assembleDebug
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: font-creator-pr-${{ github.event.pull_request.number || github.run_number }}-apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+
       - name: Restore release keystore
         if: env.PLAY_PUBLISH_ENABLED == 'true'
         env:
@@ -38,6 +48,7 @@ jobs:
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
 
       - name: Build release app bundle
+        if: env.PLAY_PUBLISH_ENABLED == 'true'
         env:
           ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -46,6 +57,7 @@ jobs:
         run: gradle :app:bundleRelease
 
       - name: Upload app bundle artifact
+        if: env.PLAY_PUBLISH_ENABLED == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: font-creator-pr-${{ github.event.pull_request.number || github.run_number }}-aab

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # The release is published only when all signing and Play credentials exist.
-      # Fork pull requests never receive repository secrets, so they remain build-only.
+      # Fork pull requests never receive repository secrets, so they receive a debug APK.
       PLAY_PUBLISH_ENABLED: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && secrets.ANDROID_KEYSTORE_PASSWORD != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' && secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
       - uses: actions/checkout@v4
@@ -30,25 +30,19 @@ jobs:
       - name: Verify the app
         run: gradle :app:testDebugUnitTest
 
-      - name: Build debug APK
-        run: gradle :app:assembleDebug
-
-      - name: Upload debug APK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: font-creator-pr-${{ github.event.pull_request.number || github.run_number }}-apk
-          path: app/build/outputs/apk/debug/app-debug.apk
-          if-no-files-found: error
-
       - name: Restore release keystore
+        id: restore_release_keystore
         if: env.PLAY_PUBLISH_ENABLED == 'true'
+        continue-on-error: true
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
 
-      - name: Build release app bundle
-        if: env.PLAY_PUBLISH_ENABLED == 'true'
+      - name: Build and upload release app
+        id: build_release_bundle
+        if: env.PLAY_PUBLISH_ENABLED == 'true' && steps.restore_release_keystore.outcome == 'success'
+        continue-on-error: true
         env:
           ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -56,16 +50,20 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: gradle :app:bundleRelease
 
-      - name: Upload app bundle artifact
-        if: env.PLAY_PUBLISH_ENABLED == 'true'
+      - name: Upload release app bundle artifact
+        id: upload_release_artifact
+        if: always() && steps.build_release_bundle.outcome == 'success'
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: font-creator-pr-${{ github.event.pull_request.number || github.run_number }}-aab
           path: app/build/outputs/bundle/release/app-release.aab
           if-no-files-found: error
 
-      - name: Upload to Google Play internal testing
-        if: env.PLAY_PUBLISH_ENABLED == 'true'
+      - name: Upload release app to Google Play internal testing
+        id: upload_to_play
+        if: always() && steps.build_release_bundle.outcome == 'success'
+        continue-on-error: true
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -73,3 +71,15 @@ jobs:
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: internal
           status: completed
+
+      - name: Build debug APK fallback
+        if: always() && (env.PLAY_PUBLISH_ENABLED != 'true' || steps.restore_release_keystore.outcome != 'success' || steps.build_release_bundle.outcome != 'success' || steps.upload_release_artifact.outcome != 'success' || steps.upload_to_play.outcome != 'success')
+        run: gradle :app:assembleDebug
+
+      - name: Upload debug APK fallback artifact
+        if: always() && (env.PLAY_PUBLISH_ENABLED != 'true' || steps.restore_release_keystore.outcome != 'success' || steps.build_release_bundle.outcome != 'success' || steps.upload_release_artifact.outcome != 'success' || steps.upload_to_play.outcome != 'success')
+        uses: actions/upload-artifact@v4
+        with:
+          name: font-creator-pr-${{ github.event.pull_request.number || github.run_number }}-apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
-# Jaafar Remote Android App
+# Font Creator
 
-A Kotlin + Jetpack Compose Android client that reads remotely managed configuration from the Render FastAPI backend.
+A Kotlin + Jetpack Compose Android app for creating and importing fonts, writing on images, and filling, signing, or stamping documents.
 
-## Before building
+## Pull-request testing
 
-1. In `app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt`, replace `BACKEND_URL` with the public Render URL for the backend.
-2. The backend must expose `GET /api/v1/mobile/config` and return `{"message":"Hello from Telegram","enabled":true}`.
-3. Build locally with Android Studio or `gradle :app:assembleDebug`.
+Every pull request runs tests and creates a release Android App Bundle (AAB) artifact.
 
-## Firebase distribution
+When the required repository secrets are configured, the same workflow also uploads the AAB to the **Google Play Internal testing** track. Install it through the Play Store testing link to test an update before merging the pull request—no APK download or uninstall is needed.
 
-The GitHub Action builds an APK on every push to `master` and keeps it as an Actions artifact. To distribute through Firebase App Distribution, add these GitHub repository secrets:
+The workflow uses GitHub's run number as Android's version code, so each PR test build is a valid upgrade.
 
-- `FIREBASE_APP_ID`
-- `FIREBASE_SERVICE_ACCOUNT_BASE64` — base64 of a Firebase service-account JSON file with App Distribution access.
+### Required GitHub secrets
 
-Create the Firebase tester group named `testers`, or change the group in `.github/workflows/android.yml`.
+- `ANDROID_KEYSTORE_BASE64`
+- `ANDROID_KEYSTORE_PASSWORD`
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` — the complete JSON of a Google Cloud service account that has Google Play Console release access.
+
+Configure the service account in Play Console under **Users and permissions**, then grant it release access for this app. The workflow only targets the **internal** track; it never publishes to closed testing or production.
 
 ## Important
 
-Telegram should control content/configuration through the backend. It must never install arbitrary APKs or execute code received from Telegram. New app code should continue through a pull request, test, merge, and signed release pipeline.
+Telegram should control content/configuration through the backend. It must never install arbitrary APKs or execute code received from Telegram. New app code should continue through pull requests, testing, merge, and a signed release pipeline.


### PR DESCRIPTION
## What changed

- Builds and verifies a release AAB for every pull request.
- Uploads the AAB to Google Play Internal testing when the required repository secrets are available.
- Keeps a downloadable AAB artifact for every PR run.
- Documents the required signing and Google Play service-account secrets.

## Why

PR builds can be installed through the Play Store before merge, so they update the existing test app without uninstalling it.

## Safety

The workflow targets only the `internal` testing track. It never promotes a build to closed testing or production.

## Validation

- Reviewed the workflow paths, package name, signing environment, and version-code behavior against the existing Gradle configuration.
