### PR TITLE
Unify Create Font and My Library journeys

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -100,7 +100,7 @@ fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
     var imageTypeface by remember { mutableStateOf<Typeface?>(null) }
     var preferredImageFontName by remember { mutableStateOf<String?>(null) }
     var initialImageText by remember { mutableStateOf("") }
-    var openDrawnLetterPicker by remember { mutableStateOf(false) }
+    var fontEntryBack by remember { mutableStateOf(Screen.Home) }
     var pendingSignatureMark by remember { mutableStateOf<String?>(null) }
     MaterialTheme(
         colorScheme = if (darkTheme) ModernDarkColors else ModernLightColors,
@@ -138,12 +138,12 @@ fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
                 Screen.Home -> HomeScreen(viewModel, { screen = it })
                 Screen.Library -> LibraryScreen(
                     vm = viewModel,
-                    back = { screen = Screen.Home },
-                    openFontManager = { screen = Screen.Fonts },
-                    openLetterEditor = {
-                        openDrawnLetterPicker = true
-                        screen = Screen.Letters
+                    back = { screen = fontEntryBack },
+                    openFontManager = {
+                        fontEntryBack = Screen.Library
+                        screen = Screen.Fonts
                     },
+                    openLetterEditor = { screen = Screen.Letters },
                     openSignatureWithMark = { markName ->
                         pendingSignatureMark = markName
                         screen = Screen.Signature
@@ -165,7 +165,7 @@ fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
                     vm = viewModel,
                     previewText = previewText,
                     changePreviewText = { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() },
-                    back = { screen = Screen.Fonts },
+                    back = { screen = Screen.Letters },
                     editLetters = { screen = Screen.Letters },
                     startDrawing = viewModel::startPaging,
                     adjustSpacing = { screen = Screen.Spacing },
@@ -177,13 +177,16 @@ fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
                 )
                 Screen.Letters -> LettersScreen(
                     vm = viewModel,
-                    back = { screen = Screen.Home },
+                    back = { screen = Screen.Library },
                     preview = { screen = Screen.FontReady },
+                    adjustSpacing = { screen = Screen.Spacing },
+                    deleteFont = {
+                        viewModel.activeProject?.name?.let(viewModel::deleteProject)
+                        screen = Screen.Library
+                    },
                     setPreviewText = { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() },
-                    showDrawnLettersOnOpen = openDrawnLetterPicker,
-                    onDrawnLettersOpened = { openDrawnLetterPicker = false },
                 )
-                Screen.Spacing -> SpacingScreen(viewModel, previewText, { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() }) { screen = Screen.Fonts }
+                Screen.Spacing -> SpacingScreen(viewModel, previewText, { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() }) { screen = Screen.Letters }
                 Screen.Image -> ImageScreen(
                     vm = viewModel,
                     back = { preferredImageFontName = null; initialImageText = ""; screen = Screen.Home },

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -138,7 +138,7 @@ fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
                 Screen.Home -> HomeScreen(viewModel, { screen = it })
                 Screen.Library -> LibraryScreen(
                     vm = viewModel,
-                    back = { screen = fontEntryBack },
+                    back = { screen = Screen.Home },
                     openFontManager = {
                         fontEntryBack = Screen.Library
                         screen = Screen.Fonts
@@ -151,7 +151,7 @@ fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
                 )
                 Screen.Fonts -> FontsScreen(
                     vm = viewModel,
-                    back = { screen = Screen.Home },
+                    back = { screen = fontEntryBack },
                     editLetters = { screen = Screen.Letters },
                     showReady = { screen = Screen.FontReady },
                     useOnImage = { fontName ->

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -103,7 +103,6 @@ import com.jaafar.remoteconfig.R
     } else {
         Text("Your letter set is complete.", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
         Button(onClick = { vm.generate(); preview() }, modifier = Modifier.fillMaxWidth()) { Text("Try your font") }
-        Text("You can start another font from Fonts whenever you are ready.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 
     if (drawn > 0) {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -59,23 +59,20 @@ import com.jaafar.remoteconfig.R
     vm: FontCreatorViewModel,
     back: () -> Unit,
     preview: () -> Unit,
+    adjustSpacing: () -> Unit,
+    deleteFont: () -> Unit,
     setPreviewText: (String) -> Unit,
-    showDrawnLettersOnOpen: Boolean,
-    onDrawnLettersOpened: () -> Unit,
-) = Page("Build ${vm.activeProject?.name.orEmpty()}", back) {
+) = Page("Font workspace", back) {
     var showEditDrawnLetters by remember { mutableStateOf(false) }
-    LaunchedEffect(showDrawnLettersOnOpen) {
-        if (showDrawnLettersOnOpen) {
-            showEditDrawnLetters = true
-            onDrawnLettersOpened()
-        }
-    }
+    var showDeleteDialog by remember { mutableStateOf(false) }
     var showPhraseDialog by remember { mutableStateOf(false) }
     var phrase by remember { mutableStateOf("") }
+    val project = vm.activeProject
     val total = vm.activeCharacterOrder.size
     val drawn = vm.drawings.size
     val nextCode = vm.activeCharacterOrder.firstOrNull { it !in vm.drawings }
 
+    Text(project?.name.orEmpty(), style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
     Text("Draw one letter at a time.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
     Surface(color = MaterialTheme.colorScheme.secondaryContainer, shape = RoundedCornerShape(14.dp)) {
         Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
@@ -111,9 +108,31 @@ import com.jaafar.remoteconfig.R
 
     if (drawn > 0) {
         OutlinedButton(onClick = { showEditDrawnLetters = true }, modifier = Modifier.fillMaxWidth()) {
-            Text("Edit drawn letters")
+            Text("Edit letters")
+        }
+        TextButton(onClick = adjustSpacing, modifier = Modifier.align(Alignment.CenterHorizontally)) {
+            Text("Adjust spacing")
         }
     }
+    TextButton(
+        onClick = { showDeleteDialog = true },
+        modifier = Modifier.align(Alignment.CenterHorizontally),
+    ) {
+        Text("Delete font", color = MaterialTheme.colorScheme.error)
+    }
+
+    if (showDeleteDialog) AlertDialog(
+        onDismissRequest = { showDeleteDialog = false },
+        title = { Text("Delete font?") },
+        text = { Text("Delete \"${project?.name.orEmpty()}\" and its generated file? This cannot be undone.") },
+        confirmButton = {
+            TextButton(onClick = {
+                showDeleteDialog = false
+                deleteFont()
+            }) { Text("Delete", color = MaterialTheme.colorScheme.error) }
+        },
+        dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") } },
+    )
 
     if (showEditDrawnLetters) AlertDialog(
         onDismissRequest = { showEditDrawnLetters = false },

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
@@ -81,78 +81,32 @@ import com.jaafar.remoteconfig.R
         }
     }
 
-    Page("Fonts", back, scrollable = true) {
-        Text("Your font studio", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
-        Text("Build a handwriting font or keep the fonts you already use in one place.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-
-        featuredProject?.let { project ->
-            val selectedCharacters = project.selectedLanguages.flatMap { it.codePoints }.filter { it != 0x20 }.toSet()
-            val total = selectedCharacters.size
-            val drawn = project.drawings.count { it.codePoint in selectedCharacters }
-            val ready = vm.hasGeneratedFont(project.name)
-            Card(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(24.dp), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)) {
-                Column(Modifier.fillMaxWidth().padding(20.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                    Text(if (ready) "YOUR FONT IS READY" else "CONTINUE WHERE YOU LEFT OFF", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
-                    Text(project.name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
-                    Text(if (ready) "Ready to use." else "$drawn of $total letters drawn", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                    if (!ready) LinearProgressIndicator(progress = if (total == 0) 0f else drawn.toFloat() / total, modifier = Modifier.fillMaxWidth())
-                    Button(onClick = {
-                        featuredIndex?.let(vm::openProject)
-                        if (ready) showReady() else editLetters()
-                    }, modifier = Modifier.fillMaxWidth()) {
-                        Text(if (ready) "Try your font" else if (drawn == 0) "Start drawing" else "Continue drawing")
-                    }
-                }
-            }
+    Page("Add a font", back) {
+        Text("Create or import", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+        Text(
+            "Create a handwriting font or import a font you already own.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Button(onClick = { showCreateDialog = true }, modifier = Modifier.fillMaxWidth()) {
+            Text("Create a handwriting font")
         }
-
-        Text("Start something new", style = MaterialTheme.typography.titleMedium)
-        Button(onClick = { showCreateDialog = true }, modifier = Modifier.fillMaxWidth()) { Text("Create a handwriting font") }
-        OutlinedButton(onClick = { fontFilePicker.launch(arrayOf("font/ttf", "font/otf", "application/octet-stream", "*/*")) }, modifier = Modifier.fillMaxWidth()) { Text("Import a font") }
-        if (vm.importStatus.isNotBlank()) Text(vm.importStatus, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
-
-        val otherProjects = vm.projects.filterIndexed { index, _ -> index != featuredIndex }
-        if (otherProjects.isNotEmpty()) {
-            Text("All handwriting fonts", style = MaterialTheme.typography.titleMedium)
-            otherProjects.forEach { project ->
-                val index = vm.projects.indexOf(project)
-                val ready = vm.hasGeneratedFont(project.name)
-                Row(Modifier.fillMaxWidth().clickable {
-                    vm.openProject(index)
-                    if (ready) showReady() else editLetters()
-                }.padding(vertical = 10.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Surface(color = MaterialTheme.colorScheme.secondaryContainer, contentColor = MaterialTheme.colorScheme.onSecondaryContainer, shape = RoundedCornerShape(12.dp), modifier = Modifier.size(44.dp)) {
-                        Box(contentAlignment = Alignment.Center) { Text("Aa", fontWeight = FontWeight.Bold) }
-                    }
-                    Column(Modifier.weight(1f)) {
-                        Text(project.name, style = MaterialTheme.typography.titleMedium)
-                        Text(if (ready) "Preview ready" else "${project.drawings.size} letters drawn", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
-                    Text(if (ready) "Try" else "Draw", color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.labelLarge)
-                }
-                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-            }
+        OutlinedButton(
+            onClick = {
+                fontFilePicker.launch(
+                    arrayOf("font/ttf", "font/otf", "application/octet-stream", "*/*"),
+                )
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Import a font")
         }
-
-        if (vm.importedFonts.isNotEmpty()) {
-            Text("Imported fonts", style = MaterialTheme.typography.titleMedium)
-            vm.importedFonts.forEach { font ->
-                Row(Modifier.fillMaxWidth().padding(vertical = 8.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Surface(color = MaterialTheme.colorScheme.surfaceVariant, contentColor = MaterialTheme.colorScheme.onSurfaceVariant, shape = RoundedCornerShape(12.dp), modifier = Modifier.size(44.dp)) {
-                        Box(contentAlignment = Alignment.Center) { Text("Aa", fontWeight = FontWeight.Bold) }
-                    }
-                    Column(Modifier.weight(1f)) {
-                        Text(font.displayName, style = MaterialTheme.typography.titleMedium)
-                        Text("Ready to use", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
-                    TextButton(onClick = { useOnImage(font.displayName) }) { Text("Use") }
-                }
-                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-            }
-        }
-
-        if (featuredProject == null && vm.importedFonts.isEmpty()) {
-            Text("Start by creating your own handwriting font or importing a .ttf or .otf file.", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        if (vm.importStatus.isNotBlank()) {
+            Text(
+                vm.importStatus,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
         }
     }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/HomeLibraryScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/HomeLibraryScreens.kt
@@ -248,7 +248,7 @@ internal fun LibraryScreen(
             OutlinedButton(openFontManager, Modifier.fillMaxWidth()) {
                 Icon(Icons.Filled.FolderOpen, contentDescription = null)
                 Spacer(Modifier.width(8.dp))
-                Text("Open font manager")
+                Text("Create or import font")
             }
         }
         LibraryTab.Signatures -> {


### PR DESCRIPTION
## Unified font journey

- Creating a handwriting font and opening an existing font now both lead to the same **Font workspace**.
- My Library opens the workspace directly instead of opening the drawn-letter picker.
- The former font manager is now a focused **Create or import font** screen; existing-font lists remain in My Library.
- The workspace groups the font’s actions: continue drawing, edit letters, adjust spacing, try the font, and delete the font.
- Try your font returns to the workspace, and spacing returns to the workspace.

## Verification

GitHub Actions runs on this PR.