### PR TITLE
Fix opening files shared to Font Creator

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
       android:grantUriPermissions="true">
       <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
     </provider>
-    <activity android:name=".MainActivity" android:exported="true">
+    <activity android:name=".MainActivity" android:exported="true" android:grantUriPermissions="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,11 +15,13 @@
       </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.SEND" />
+        <action android:name="android.intent.action.SEND_MULTIPLE" />
         <category android:name="android.intent.category.DEFAULT" />
         <data android:mimeType="application/pdf" />
       </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.SEND" />
+        <action android:name="android.intent.action.SEND_MULTIPLE" />
         <category android:name="android.intent.category.DEFAULT" />
         <data android:mimeType="image/*" />
       </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
       android:grantUriPermissions="true">
       <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
     </provider>
-    <activity android:name=".MainActivity" android:exported="true" android:grantUriPermissions="true">
+    <activity android:name=".MainActivity" android:exported="true" android:grantUriPermissions="true" android:launchMode="singleTop">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
@@ -34,19 +34,39 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    /** Returns a PDF or image URI received via the Android Share sheet, or null. */
+    /**
+     * Returns the first PDF or image received from Android's Share sheet.
+     * Google Photos can use ACTION_SEND_MULTIPLE even when a single image is selected.
+     */
     private fun extractSharedDocumentUri(intent: Intent?): Uri? {
-        if (intent?.action != Intent.ACTION_SEND) return null
+        val action = intent?.action
+        if (action != Intent.ACTION_SEND && action != Intent.ACTION_SEND_MULTIPLE) return null
         val mimeType = intent.type ?: return null
         if (mimeType != "application/pdf" && !mimeType.startsWith("image/")) return null
-        val streamUri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            intent.getParcelableExtra(Intent.EXTRA_STREAM)
+
+        val streamUri = when (action) {
+            Intent.ACTION_SEND -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableExtra(Intent.EXTRA_STREAM)
+                }
+            }
+            else -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri::class.java)
+                        ?.firstOrNull()
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
+                        ?.firstOrNull()
+                }
+            }
         }
 
         // Some Android share sheets provide the URI only in ClipData.
         return streamUri ?: intent.clipData?.getItemAt(0)?.uri
     }
+
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
@@ -6,19 +6,35 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModelProvider
 import com.jaafar.remoteconfig.fontcreator.FontCreatorApp
 import com.jaafar.remoteconfig.fontcreator.FontCreatorViewModel
 
 class MainActivity : ComponentActivity() {
+    private var sharedUri by mutableStateOf<Uri?>(null)
+    private var shareRequestId by mutableIntStateOf(0)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val viewModel = ViewModelProvider(this)[FontCreatorViewModel::class.java]
-        val sharedUri = extractSharedDocumentUri(intent)
-        setContent { FontCreatorApp(viewModel, sharedUri) }
+        sharedUri = extractSharedDocumentUri(intent)
+        setContent { FontCreatorApp(viewModel, sharedUri, shareRequestId) }
     }
 
-    /** Returns a PDF or image URI received via ACTION_SEND, or null. */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        extractSharedDocumentUri(intent)?.let { uri ->
+            sharedUri = uri
+            shareRequestId += 1
+        }
+    }
+
+    /** Returns a PDF or image URI received via the Android Share sheet, or null. */
     private fun extractSharedDocumentUri(intent: Intent?): Uri? {
         if (intent?.action != Intent.ACTION_SEND) return null
         val mimeType = intent.type ?: return null

--- a/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
@@ -39,11 +39,14 @@ class MainActivity : ComponentActivity() {
         if (intent?.action != Intent.ACTION_SEND) return null
         val mimeType = intent.type ?: return null
         if (mimeType != "application/pdf" && !mimeType.startsWith("image/")) return null
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        val streamUri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
         } else {
             @Suppress("DEPRECATION")
             intent.getParcelableExtra(Intent.EXTRA_STREAM)
         }
+
+        // Some Android share sheets provide the URI only in ClipData.
+        return streamUri ?: intent.clipData?.getItemAt(0)?.uri
     }
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/DocumentUtils.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/DocumentUtils.kt
@@ -55,14 +55,55 @@ internal fun getPdfPageCount(context: Context, uri: Uri): Int {
     return descriptor.use { pfd -> PdfRenderer(pfd).use { it.pageCount } }
 }
 
-internal fun loadBitmap(resolver: ContentResolver, uri: Uri): Bitmap? = runCatching {
-    if (Build.VERSION.SDK_INT >= 28) {
-        ImageDecoder.decodeBitmap(ImageDecoder.createSource(resolver, uri)) { decoder, _, _ ->
-            decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+/**
+ * Decodes a shared image without loading an entire camera photo into memory.
+ * Gallery apps often share 12–50 MP images; scaling them for the editor avoids
+ * a silent out-of-memory failure while keeping enough detail for marking.
+ */
+internal fun loadBitmap(resolver: ContentResolver, uri: Uri): Bitmap? {
+    val maxEditorDimension = 2_048
+    val decoded = runCatching {
+        if (Build.VERSION.SDK_INT >= 28) {
+            ImageDecoder.decodeBitmap(ImageDecoder.createSource(resolver, uri)) { decoder, info, _ ->
+                decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+                val source = info.size
+                val largestSide = maxOf(source.width, source.height)
+                if (largestSide > maxEditorDimension) {
+                    val scale = maxEditorDimension.toFloat() / largestSide.toFloat()
+                    decoder.setTargetSize(
+                        (source.width * scale).toInt().coerceAtLeast(1),
+                        (source.height * scale).toInt().coerceAtLeast(1),
+                    )
+                }
+            }
+        } else {
+            decodeSampledBitmap(resolver, uri, maxEditorDimension)
         }
-    } else {
-        @Suppress("DEPRECATION")
-        resolver.openInputStream(uri).use { input -> BitmapFactory.decodeStream(input) }
+    }.getOrNull()
+    return decoded ?: decodeSampledBitmap(resolver, uri, maxEditorDimension)
+}
+
+private fun decodeSampledBitmap(
+    resolver: ContentResolver,
+    uri: Uri,
+    maxDimension: Int,
+): Bitmap? = runCatching {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    resolver.openInputStream(uri).use { input ->
+        BitmapFactory.decodeStream(input, null, bounds)
+    }
+    if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return@runCatching null
+
+    var sampleSize = 1
+    while (bounds.outWidth / sampleSize > maxDimension || bounds.outHeight / sampleSize > maxDimension) {
+        sampleSize *= 2
+    }
+    val options = BitmapFactory.Options().apply {
+        inSampleSize = sampleSize
+        inPreferredConfig = Bitmap.Config.ARGB_8888
+    }
+    resolver.openInputStream(uri).use { input ->
+        BitmapFactory.decodeStream(input, null, options)
     }
 }.getOrNull()
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -204,6 +204,12 @@ internal fun FillMarkScreen(
 ) {
     var documentUri by remember { mutableStateOf(initialUri) }
 
+    // Update the editor when another document is shared while the app is already open.
+    LaunchedEffect(initialUri) {
+        if (initialUri != null) documentUri = initialUri
+    }
+
+
     if (documentUri == null) {
         FillMarkLandingScreen(
             onDocumentChosen = { uri -> documentUri = uri },

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -89,7 +89,11 @@ internal enum class LibraryTab(val label: String) { Fonts("Fonts"), Signatures("
 internal enum class LibrarySignaturePage { Hub, Draw, ImportStamp }
 
 @Composable
-fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
+fun FontCreatorApp(
+    viewModel: FontCreatorViewModel,
+    sharedUri: Uri? = null,
+    shareRequestId: Int = 0,
+) {
     val context = LocalContext.current
     val preferences = remember { context.getSharedPreferences("appearance", 0) }
     var darkTheme by remember { mutableStateOf(preferences.getBoolean("dark_theme", false)) }
@@ -104,6 +108,16 @@ fun FontCreatorApp(viewModel: FontCreatorViewModel, sharedUri: Uri? = null) {
     var autoPickImage by remember { mutableStateOf(false) }
     var fontEntryBack by remember { mutableStateOf(Screen.Home) }
     var pendingSignatureMark by remember { mutableStateOf<String?>(null) }
+
+    // A running activity receives subsequent Share-sheet requests through onNewIntent.
+    // Route every request straight to the editor, including a re-shared copy of the same file.
+    LaunchedEffect(sharedUri, shareRequestId) {
+        sharedUri ?: return@LaunchedEffect
+        showTutorial = false
+        fillMarkUri = sharedUri
+        screen = Screen.FillMark
+    }
+
     MaterialTheme(
         colorScheme = if (darkTheme) ModernDarkColors else ModernLightColors,
         typography = appTypography(null),


### PR DESCRIPTION
## What changed
- Handles Share-sheet requests even while Font Creator is already open.
- Takes the user directly to **Fill & Mark** with the shared PDF or image.
- Refreshes the editor when a second file is shared.
- Allows the activity to receive temporary access to the shared file.

## Test
- CI build will validate the Android project.
- Manual check: open a photo or PDF → **Share** → **Font Creator**. The document should open directly in Fill & Mark.