### PR TITLE
Support Google Photos image handoff

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,12 @@
         <category android:name="android.intent.category.DEFAULT" />
         <data android:mimeType="image/*" />
       </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.EDIT" />
+        <action android:name="com.google.android.apps.photos.OEM_EDIT" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:mimeType="image/*" />
+      </intent-filter>
     </activity>
   </application>
 </manifest>

--- a/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/MainActivity.kt
@@ -35,14 +35,15 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Returns the first PDF or image received from Android's Share sheet.
-     * Google Photos can use ACTION_SEND_MULTIPLE even when a single image is selected.
+     * Returns the first PDF or image received from a share or edit request.
+     * Google Photos may use either a stream, ClipData, or the intent data URI.
      */
     private fun extractSharedDocumentUri(intent: Intent?): Uri? {
         val action = intent?.action
-        if (action != Intent.ACTION_SEND && action != Intent.ACTION_SEND_MULTIPLE) return null
-        val mimeType = intent.type ?: return null
-        if (mimeType != "application/pdf" && !mimeType.startsWith("image/")) return null
+        val isShare = action == Intent.ACTION_SEND || action == Intent.ACTION_SEND_MULTIPLE
+        val isImageEdit = action == Intent.ACTION_EDIT ||
+            action == "com.google.android.apps.photos.OEM_EDIT"
+        if (!isShare && !isImageEdit) return null
 
         val streamUri = when (action) {
             Intent.ACTION_SEND -> {
@@ -53,7 +54,7 @@ class MainActivity : ComponentActivity() {
                     intent.getParcelableExtra(Intent.EXTRA_STREAM)
                 }
             }
-            else -> {
+            Intent.ACTION_SEND_MULTIPLE -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri::class.java)
                         ?.firstOrNull()
@@ -63,10 +64,11 @@ class MainActivity : ComponentActivity() {
                         ?.firstOrNull()
                 }
             }
+            else -> null
         }
-
-        // Some Android share sheets provide the URI only in ClipData.
-        return streamUri ?: intent.clipData?.getItemAt(0)?.uri
+        val uri = streamUri ?: intent.clipData?.getItemAt(0)?.uri ?: intent.data ?: return null
+        val mimeType = intent.type ?: contentResolver.getType(uri)
+        return if (mimeType == "application/pdf" || mimeType?.startsWith("image/") == true) uri else null
     }
 
 }


### PR DESCRIPTION
## What changed
- Reads shared images from stream extras, ClipData, and the intent data URI.
- Supports the Google Photos **Edit in** handoff as well as standard sharing.
- Keeps PDF and device-Gallery sharing unchanged.

## Important
Some cloud-only Google Photos shares do not grant third-party apps read access. Android blocks all apps from opening those private URIs; the supported route is Google Photos **Edit in** or saving the image to the device first.