### PR TITLE
Simplify letter editor navigation warnings

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -160,7 +160,6 @@ fun FontCreatorApp(
                 onSave = viewModel::saveDrawing,
                 onSaveAndContinue = viewModel::saveDrawingAndContinue,
                 onSaveAndStay = viewModel::saveDrawingAndStay,
-                onSaveAndClose = viewModel::saveDrawingAndClose,
             )
             else -> when (screen) {
                 Screen.Home -> HomeScreen(viewModel, { screen = it })

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -214,12 +214,6 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         isPagingMode = false
     }
 
-    fun saveDrawingAndClose(drawing: GlyphDrawing) {
-        drawings[drawing.codePoint] = drawing
-        syncActive(); persist(); status = "Letter saved."
-        closeEditor()
-    }
-
     fun generate() {
         val project = activeProject ?: return
         if (drawings.isEmpty()) { status = "Draw at least one character first."; return }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -274,7 +274,6 @@ private fun SpacingControl(
     onSave: (GlyphDrawing) -> Unit,
     onSaveAndContinue: (GlyphDrawing) -> Unit,
     onSaveAndStay: (GlyphDrawing) -> Unit,
-    onSaveAndClose: (GlyphDrawing) -> Unit,
 ) {
     var strokes by remember(codePoint) { mutableStateOf(initial?.strokes ?: emptyList()) }
     var active by remember(codePoint) { mutableStateOf<List<GlyphPoint>>(emptyList()) }
@@ -287,7 +286,9 @@ private fun SpacingControl(
     var pendingNavigation by remember { mutableStateOf<(() -> Unit)?>(null) }
     var savedStrokes by remember(codePoint) { mutableStateOf(initial?.strokes ?: emptyList()) }
     var savedStrokeWidth by remember(codePoint) { mutableFloatStateOf(initial?.strokeWidth ?: 8f) }
-    val isDirty = strokes != savedStrokes || strokeWidth != savedStrokeWidth
+    val strokesChanged = strokes != savedStrokes
+    val thicknessChanged = strokes.isNotEmpty() && strokeWidth != savedStrokeWidth
+    val isDirty = strokesChanged || thicknessChanged
     val navigateSafely: (() -> Unit) -> Unit = { action ->
         if (isDirty) {
             pendingNavigation = action
@@ -361,17 +362,6 @@ private fun SpacingControl(
                             trailingIcon = { Checkbox(checked = showReference, onCheckedChange = null) },
                             onClick = { showReference = !showReference; showMoreMenu = false },
                         )
-                        if (!pagingMode) {
-                            HorizontalDivider()
-                            DropdownMenuItem(
-                                text = { Text("Save & close") },
-                                enabled = strokes.isNotEmpty(),
-                                onClick = {
-                                    showMoreMenu = false
-                                    onSaveAndClose(drawing())
-                                },
-                            )
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Follow-up to #192.

- Removes Save & close from the overflow menu
- Applies one navigation rule to both Back and character switching
- Leaves an empty new canvas immediately without a warning
- Leaves unchanged saved drawings immediately
- Warns only when strokes were added, modified, or an existing drawing was cleared
- Allows customers to move to any character without completing the current one