### PR TITLE
Remove phrase-based font drawing flow

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -179,7 +179,10 @@ fun FontCreatorApp(
                 Screen.Fonts -> FontsScreen(
                     vm = viewModel,
                     back = { screen = fontEntryBack },
-                    editLetters = { screen = Screen.Letters },
+                    editLetters = {
+                        screen = Screen.Letters
+                        viewModel.editLetters()
+                    },
                     showReady = { screen = Screen.FontReady },
                     useOnImage = { fontName ->
                         preferredImageFontName = fontName

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -186,7 +186,6 @@ fun FontCreatorApp(
                         initialImageText = ""
                         screen = Screen.Image
                     },
-                    setPreviewText = { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() },
                 )
                 Screen.FontReady -> FontReadyScreen(
                     vm = viewModel,
@@ -207,7 +206,6 @@ fun FontCreatorApp(
                     back = { screen = Screen.Library },
                     preview = { screen = Screen.FontReady },
                     adjustSpacing = { screen = Screen.Spacing },
-                    setPreviewText = { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() },
                 )
                 Screen.Spacing -> SpacingScreen(viewModel, previewText, { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() }) { screen = Screen.Letters }
                 Screen.Image -> ImageScreen(

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -144,7 +144,6 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     }
 
     fun startPaging() = startQueue(activeCharacterOrder.filter { it !in drawings }, "All supported characters have already been drawn.")
-    fun drawMissingCharacters(text: String) = startQueue(text.asSequence().map { it.code }.filter { it != 0x20 && it in activeCharacterOrder && it !in drawings }.distinct().toList(), "This text has no missing supported characters.")
     private fun startQueue(queue: List<Int>, emptyMessage: String) {
         if (queue.isEmpty()) { status = emptyMessage; return }
         pagingQueue = queue

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -60,14 +60,11 @@ import com.jaafar.remoteconfig.R
     back: () -> Unit,
     preview: () -> Unit,
     adjustSpacing: () -> Unit,
-    setPreviewText: (String) -> Unit,
 ) = Page("Font workspace", back, actions = {
     val file = vm.generatedFont
     val project = vm.activeProject
     if (file != null && project != null) ShareButton(file, project.name)
 }) {
-    var showPhraseDialog by remember { mutableStateOf(false) }
-    var phrase by remember { mutableStateOf("") }
     val project = vm.activeProject
     val total = vm.activeCharacterOrder.size
     val drawn = vm.drawings.size
@@ -89,22 +86,12 @@ import com.jaafar.remoteconfig.R
             Spacer(Modifier.width(8.dp))
             Text("Start drawing")
         }
-        OutlinedButton(onClick = { phrase = ""; showPhraseDialog = true }, modifier = Modifier.fillMaxWidth()) {
-            Icon(Icons.Filled.Edit, contentDescription = null)
-            Spacer(Modifier.width(8.dp))
-            Text("Use a phrase")
-        }
     } else if (nextCode != null) {
         Text("Keep building your font.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Button(onClick = { vm.edit(nextCode) }, modifier = Modifier.fillMaxWidth()) {
             Icon(Icons.Filled.Edit, contentDescription = null)
             Spacer(Modifier.width(8.dp))
             Text("Continue drawing")
-        }
-        OutlinedButton(onClick = { phrase = ""; showPhraseDialog = true }, modifier = Modifier.fillMaxWidth()) {
-            Icon(Icons.Filled.Edit, contentDescription = null)
-            Spacer(Modifier.width(8.dp))
-            Text("Draw letters from a phrase")
         }
         OutlinedButton(onClick = { vm.generate(); preview() }, modifier = Modifier.fillMaxWidth()) {
             Icon(Icons.Filled.Visibility, contentDescription = null)
@@ -132,26 +119,6 @@ import com.jaafar.remoteconfig.R
             Text("Adjust spacing")
         }
     }
-    if (showPhraseDialog) AlertDialog(
-        onDismissRequest = { showPhraseDialog = false },
-        title = { Text("Use a phrase") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Type a phrase. You will draw its missing letters first.")
-                OutlinedTextField(phrase, { phrase = it }, Modifier.fillMaxWidth(), label = { Text("Phrase") }, minLines = 3)
-            }
-        },
-        confirmButton = {
-            Button(onClick = {
-                vm.drawMissingCharacters(phrase)
-                setPreviewText(phrase)
-                showPhraseDialog = false
-            }, enabled = phrase.isNotBlank()) { Text("Start drawing") }
-        },
-        dismissButton = { TextButton(onClick = { showPhraseDialog = false }) { Text("Cancel") } },
-    )
-
-
 }
 
 @Composable

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
@@ -59,13 +59,10 @@ import com.jaafar.remoteconfig.R
     editLetters: () -> Unit,
     showReady: () -> Unit,
     useOnImage: (String) -> Unit,
-    setPreviewText: (String) -> Unit,
 ) {
     val context = LocalContext.current
     var name by remember { mutableStateOf("") }
     var showCreateDialog by remember { mutableStateOf(false) }
-    var showAddCharsSetupDialog by remember { mutableStateOf(false) }
-    var setupCharsText by remember { mutableStateOf("") }
     var showImportNameDialog by remember { mutableStateOf(false) }
     var importPendingUri by remember { mutableStateOf<Uri?>(null) }
     var importDisplayName by remember { mutableStateOf("") }
@@ -125,7 +122,7 @@ import com.jaafar.remoteconfig.R
                 keyboardController?.show()
             }
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Next, you will choose the letters to draw. You can add more any time.")
+                Text("Next, you will start drawing your letters. You can return and continue any time.")
                 OutlinedTextField(
                     name,
                     { name = it },
@@ -144,10 +141,9 @@ import com.jaafar.remoteconfig.R
                 if (vm.createProject(name)) {
                     showCreateDialog = false
                     name = ""
-                    setupCharsText = ""
-                    showAddCharsSetupDialog = true
+                    editLetters()
                 }
-            }, enabled = name.isNotBlank() && !duplicateProjectName) { Text("Choose letters") }
+            }, enabled = name.isNotBlank() && !duplicateProjectName) { Text("Create font") }
         },
         dismissButton = { TextButton(onClick = { showCreateDialog = false; name = "" }) { Text("Cancel") } },
     )
@@ -168,27 +164,6 @@ import com.jaafar.remoteconfig.R
             }, enabled = importDisplayName.isNotBlank()) { Text("Import") }
         },
         dismissButton = { TextButton(onClick = { showImportNameDialog = false; importPendingUri = null }) { Text("Cancel") } },
-    )
-    if (showAddCharsSetupDialog) AlertDialog(
-        onDismissRequest = { showAddCharsSetupDialog = false; editLetters() },
-        title = { Text("Start with the letters you need") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Optional: paste a useful phrase. We will put its letters first. You can also choose letters yourself.")
-                OutlinedTextField(setupCharsText, { setupCharsText = it }, Modifier.fillMaxWidth(), label = { Text("Useful phrase") }, minLines = 3)
-            }
-        },
-        confirmButton = {
-            if (setupCharsText.isNotBlank()) {
-                Button(onClick = {
-                    vm.drawMissingCharacters(setupCharsText)
-                    setPreviewText(setupCharsText)
-                    showAddCharsSetupDialog = false
-                    editLetters()
-                }) { Text("Use this phrase") }
-            }
-        },
-        dismissButton = { TextButton(onClick = { showAddCharsSetupDialog = false; editLetters() }) { Text("Choose letters myself") } },
     )
 }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/HomeLibraryScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/HomeLibraryScreens.kt
@@ -163,7 +163,7 @@ internal fun FeatureTutorial(onFinished: () -> Unit) {
     val pages = listOf(
         TutorialPage(
             "Create a font",
-            "Turn your handwriting into a font. Start with the letters you use most, then try a phrase.",
+            "Turn your handwriting into a font by drawing each character in your own style.",
             Icons.Filled.TextFields,
         ),
         TutorialPage(


### PR DESCRIPTION
- Removes the optional phrase step after creating a handwriting font
- Opens the letter editor immediately after font creation
- Removes Use a phrase and Draw letters from a phrase from the Font Workspace
- Removes the unused phrase queue action and callbacks
- Updates tutorial copy to match the simplified character-by-character flow