### PR TITLE
Fix default reference letter rendering

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -288,23 +288,23 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         prefs.edit().putString("reference_font", key).apply()
     }
 
-    fun referenceTypeface(): Typeface? {
+    fun referenceTypeface(): Typeface {
         val app = getApplication<Application>()
         return when (referenceFontKey) {
-            "Default" -> null
+            "Default" -> Typeface.DEFAULT
             "Sans-serif" -> Typeface.SANS_SERIF
             "Serif" -> Typeface.SERIF
             "Monospace" -> Typeface.MONOSPACE
             else -> {
                 val imported = importedFonts.firstOrNull { it.displayName == referenceFontKey }
                 if (imported != null) {
-                    runCatching { loadTypeface(File(app.filesDir, imported.fileName)) }.getOrNull()
+                    runCatching { loadTypeface(File(app.filesDir, imported.fileName)) }.getOrDefault(Typeface.DEFAULT)
                 } else {
                     val project = projects.firstOrNull { it.name == referenceFontKey }
                     if (project != null) {
                         val file = generatedFile(project.name)
-                        runCatching { if (file.exists()) loadTypeface(file) else null }.getOrNull()
-                    } else null
+                        runCatching { if (file.exists()) loadTypeface(file) else Typeface.DEFAULT }.getOrDefault(Typeface.DEFAULT)
+                    } else Typeface.DEFAULT
                 }
             }
         }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -233,7 +233,7 @@ private fun SpacingControl(
     pagingMode: Boolean,
     pagingProgress: Pair<Int, Int>?,
     canGoPrevious: Boolean,
-    referenceTypeface: Typeface?,
+    referenceTypeface: Typeface,
     onCancel: () -> Unit,
     onPrevious: () -> Unit,
     onSelectCharacter: (Int) -> Unit,
@@ -416,7 +416,7 @@ private fun SpacingControl(
                     },
             ) {
                 canvasSize = size.width to size.height
-                if (showReference && referenceTypeface != null) {
+                if (showReference) {
                     drawIntoCanvas { canvas ->
                         val paint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
                             typeface = referenceTypeface


### PR DESCRIPTION
- Resolves the Default reference-font option to `Typeface.DEFAULT` instead of null
- Makes the reference typeface resolver always return a valid font
- Falls back to the platform default when an imported or generated reference font is missing or cannot load
- Ensures the canvas reference toggle works for every Settings selection