### PR TITLE
Expose all current Library fonts in Fill & Mark

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -304,7 +304,7 @@ private fun FillMarkEditorScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val fontOptions = remember(vm.projects.toList(), vm.importedFonts.toList(), vm.generatedFont) {
-        vm.availableFontOptions()
+        vm.allFontOptions()
     }
 
     // Document state
@@ -329,7 +329,7 @@ private fun FillMarkEditorScreen(
     // Per-tool config state (shared across marks for ergonomics)
     var configText by remember { mutableStateOf(initialText ?: "") }
     var configColorIdx by remember { mutableIntStateOf(0) }
-    var configFontIdx by remember { mutableIntStateOf(0) }
+    var configFontIdx by remember { mutableIntStateOf(-1) }
     var configSizeFraction by remember { mutableFloatStateOf(0.20f) }
     var configCheckStyle by remember { mutableStateOf(CheckStyle.Check) }
     val defaultSignatureName = vm.signatures.firstOrNull { it.imageFileName == null && it.name == vm.defaultSignatureName }?.name
@@ -419,7 +419,7 @@ private fun FillMarkEditorScreen(
         val m = marks.firstOrNull { it.id == selectedMarkId } ?: return@LaunchedEffect
         configText = m.text
         configColorIdx = textColors.indexOfFirst { it.second == m.colorArgb }.takeIf { it >= 0 } ?: 0
-        configFontIdx = fontOptions.indexOfFirst { it.first == (m.fontKey ?: "Default") }.takeIf { it >= 0 } ?: 0
+        configFontIdx = fontOptions.indexOfFirst { it.first == m.fontKey }.takeIf { it >= 0 } ?: -1
         configSizeFraction = m.sizeFraction
         configCheckStyle = m.checkStyle
         configSignatureName = m.signatureName
@@ -502,7 +502,7 @@ private fun FillMarkEditorScreen(
 
     // Export action – captured in a lambda so the icon button in the top bar can trigger it.
     fun triggerExport() {
-        val fontOptionsSnapshot = vm.availableFontOptions()
+        val fontOptionsSnapshot = vm.allFontOptions()
         val signaturesSnapshot = vm.signatures.toList()
         scope.launch {
             isProcessing = true
@@ -977,6 +977,12 @@ private fun TextMarkStyleControls(
                 .horizontalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
+            val defaultLabel = "Default"
+            if (fontIdx < 0) {
+                Button(onClick = {}) { Text(defaultLabel) }
+            } else {
+                OutlinedButton(onClick = { onFontChange(-1) }) { Text(defaultLabel) }
+            }
             fontOptions.forEachIndexed { idx, (name, _) ->
                 if (idx == fontIdx) {
                     Button(onClick = {}) { Text(name, maxLines = 1) }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -303,7 +303,9 @@ private fun FillMarkEditorScreen(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val fontOptions = remember { vm.allFontOptions() }
+    val fontOptions = remember(vm.projects.toList(), vm.importedFonts.toList(), vm.generatedFont) {
+        vm.availableFontOptions()
+    }
 
     // Document state
     var isPdf by remember { mutableStateOf(false) }
@@ -327,7 +329,7 @@ private fun FillMarkEditorScreen(
     // Per-tool config state (shared across marks for ergonomics)
     var configText by remember { mutableStateOf(initialText ?: "") }
     var configColorIdx by remember { mutableIntStateOf(0) }
-    var configFontIdx by remember { mutableIntStateOf(-1) }
+    var configFontIdx by remember { mutableIntStateOf(0) }
     var configSizeFraction by remember { mutableFloatStateOf(0.20f) }
     var configCheckStyle by remember { mutableStateOf(CheckStyle.Check) }
     val defaultSignatureName = vm.signatures.firstOrNull { it.imageFileName == null && it.name == vm.defaultSignatureName }?.name
@@ -417,7 +419,7 @@ private fun FillMarkEditorScreen(
         val m = marks.firstOrNull { it.id == selectedMarkId } ?: return@LaunchedEffect
         configText = m.text
         configColorIdx = textColors.indexOfFirst { it.second == m.colorArgb }.takeIf { it >= 0 } ?: 0
-        configFontIdx = fontOptions.indexOfFirst { it.first == m.fontKey }.takeIf { it >= 0 } ?: -1
+        configFontIdx = fontOptions.indexOfFirst { it.first == (m.fontKey ?: "Default") }.takeIf { it >= 0 } ?: 0
         configSizeFraction = m.sizeFraction
         configCheckStyle = m.checkStyle
         configSignatureName = m.signatureName
@@ -500,7 +502,7 @@ private fun FillMarkEditorScreen(
 
     // Export action – captured in a lambda so the icon button in the top bar can trigger it.
     fun triggerExport() {
-        val fontOptionsSnapshot = vm.allFontOptions()
+        val fontOptionsSnapshot = vm.availableFontOptions()
         val signaturesSnapshot = vm.signatures.toList()
         scope.launch {
             isProcessing = true
@@ -975,12 +977,6 @@ private fun TextMarkStyleControls(
                 .horizontalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            val defaultLabel = "Default"
-            if (fontIdx < 0) {
-                Button(onClick = {}) { Text(defaultLabel) }
-            } else {
-                OutlinedButton(onClick = { onFontChange(-1) }) { Text(defaultLabel) }
-            }
             fontOptions.forEachIndexed { idx, (name, _) ->
                 if (idx == fontIdx) {
                     Button(onClick = {}) { Text(name, maxLines = 1) }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -328,9 +328,9 @@ private const val PREF_KEY_LAST_IMAGE_FONT = "last_font"
 ) {
     val context = LocalContext.current
     val preferences = remember { context.getSharedPreferences("image_editor", 0) }
-    val allAvailable = remember(vm.projects.toList(), vm.importedFonts.toList(), vm.generatedFont) {
-        vm.availableFontOptions()
-    }
+    val allFonts = remember(vm.projects.toList(), vm.importedFonts.toList(), vm.generatedFont) { vm.allFontOptions() }
+    val systemFonts = listOf("Default" to Typeface.DEFAULT, "Serif" to Typeface.SERIF, "Sans-Serif" to Typeface.SANS_SERIF, "Monospace" to Typeface.MONOSPACE)
+    val allAvailable = systemFonts + allFonts
     val lastSavedFont = remember { preferences.getString(PREF_KEY_LAST_IMAGE_FONT, null) }
     var selectedFontLabel by remember(allAvailable, initiallySelectedFont) {
         val resolved = when {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -328,9 +328,9 @@ private const val PREF_KEY_LAST_IMAGE_FONT = "last_font"
 ) {
     val context = LocalContext.current
     val preferences = remember { context.getSharedPreferences("image_editor", 0) }
-    val allFonts = remember(vm.projects, vm.importedFonts) { vm.allFontOptions() }
-    val systemFonts = listOf("Default" to Typeface.DEFAULT, "Serif" to Typeface.SERIF, "Sans-Serif" to Typeface.SANS_SERIF, "Monospace" to Typeface.MONOSPACE)
-    val allAvailable = systemFonts + allFonts
+    val allAvailable = remember(vm.projects.toList(), vm.importedFonts.toList(), vm.generatedFont) {
+        vm.availableFontOptions()
+    }
     val lastSavedFont = remember { preferences.getString(PREF_KEY_LAST_IMAGE_FONT, null) }
     var selectedFontLabel by remember(allAvailable, initiallySelectedFont) {
         val resolved = when {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -76,8 +76,20 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     fun allFontOptions(): List<Pair<String, Typeface>> {
         val app = getApplication<Application>()
         val generated = projects.mapNotNull { project ->
+            if (project.drawings.isEmpty()) return@mapNotNull null
             val file = generatedFile(project.name)
-            if (file.exists()) runCatching { project.name to loadTypeface(file) }.getOrNull() else null
+            runCatching {
+                // Keep Library fonts usable and current even if the user has not opened Preview.
+                file.writeBytes(
+                    TrueTypeGenerator().generate(
+                        project.drawings,
+                        project.wordSpacingMm,
+                        project.letterSpacingMm,
+                        project.name,
+                    ),
+                )
+                project.name to loadTypeface(file)
+            }.getOrNull()
         }
         val imported = importedFonts.mapNotNull { font ->
             val file = File(app.filesDir, font.fileName)
@@ -85,16 +97,6 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         }
         return generated + imported
     }
-
-    /** Complete font catalog shared by every text editor. */
-    fun availableFontOptions(): List<Pair<String, Typeface>> = (
-        listOf(
-            "Default" to Typeface.DEFAULT,
-            "Sans-serif" to Typeface.SANS_SERIF,
-            "Serif" to Typeface.SERIF,
-            "Monospace" to Typeface.MONOSPACE,
-        ) + allFontOptions()
-    ).distinctBy { it.first }
 
     fun createProject(name: String): Boolean {
         val clean = name.trim()

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -86,6 +86,16 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         return generated + imported
     }
 
+    /** Complete font catalog shared by every text editor. */
+    fun availableFontOptions(): List<Pair<String, Typeface>> = (
+        listOf(
+            "Default" to Typeface.DEFAULT,
+            "Sans-serif" to Typeface.SANS_SERIF,
+            "Serif" to Typeface.SERIF,
+            "Monospace" to Typeface.MONOSPACE,
+        ) + allFontOptions()
+    ).distinctBy { it.first }
+
     fun createProject(name: String): Boolean {
         val clean = name.trim()
         if (clean.isBlank()) { status = "Enter a name for the font."; return false }


### PR DESCRIPTION
- Makes every handwriting font with saved drawings available in Fill & Mark, even if Preview was never opened
- Regenerates Library font files from the latest saved drawings and spacing so editors do not use stale versions
- Keeps imported Library fonts available
- Refreshes Fill & Mark and Edit Image when the Library changes
- Preserves the existing predefined-font behavior and legacy Default selection