### PR TITLE
Fix completed-font save navigation and saved thickness

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -147,6 +147,7 @@ fun FontCreatorApp(
             viewModel.selectedCodePoint != null -> GlyphEditorScreen(
                 codePoint = viewModel.selectedCodePoint!!,
                 initial = viewModel.drawings[viewModel.selectedCodePoint],
+                defaultStrokeWidth = viewModel.lastStrokeWidth,
                 drawings = viewModel.drawings,
                 characterOrder = viewModel.activeCharacterOrder,
                 pagingMode = viewModel.isPagingMode,

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -69,6 +70,7 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     var defaultSignatureName by mutableStateOf(prefs.getString(PREFS_DEFAULT_SIGNATURE, null)); private set
     var defaultStampName by mutableStateOf(prefs.getString(PREFS_DEFAULT_STAMP, null)); private set
     var lastEditedCodePoint by mutableStateOf<Int?>(null); private set
+    var lastStrokeWidth by mutableFloatStateOf(8f); private set
 
     /** Returns all available typefaces (generated + imported) with their display labels. */
     fun hasGeneratedFont(name: String): Boolean = generatedFile(name).exists()
@@ -125,6 +127,7 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         activeProjectIndex = index; drawings.clear(); drawings.putAll(project.drawings.associateBy { it.codePoint })
         selectedCodePoint = null; generatedFont = generatedFile(project.name).takeIf { it.exists() }
         previewTypeface = generatedFont?.let { runCatching { loadTypeface(it) }.getOrNull() }
+        lastStrokeWidth = 8f
         status = ""
     }
 
@@ -198,6 +201,7 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     }
 
     fun saveDrawing(drawing: GlyphDrawing) {
+        lastStrokeWidth = drawing.strokeWidth
         drawings[drawing.codePoint] = drawing
         if (isPagingMode) {
             pagingHistory = pagingHistory + drawing.codePoint
@@ -209,16 +213,16 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     }
 
     fun saveDrawingAndContinue(drawing: GlyphDrawing) {
+        lastStrokeWidth = drawing.strokeWidth
         drawings[drawing.codePoint] = drawing
         syncActive(); persist(); status = "Letter saved."
         val order = activeCharacterOrder
-        val currentIndex = order.indexOf(drawing.codePoint).coerceAtLeast(0)
-        selectedCodePoint = (order.drop(currentIndex + 1) + order.take(currentIndex + 1))
-            .firstOrNull { it !in drawings }
+        selectedCodePoint = nextCharacterAfterSave(order, drawing.codePoint, drawings.keys)
         isPagingMode = false
     }
 
     fun saveDrawingAndStay(drawing: GlyphDrawing) {
+        lastStrokeWidth = drawing.strokeWidth
         drawings[drawing.codePoint] = drawing
         syncActive(); persist(); status = "Letter saved."
         selectedCodePoint = drawing.codePoint
@@ -468,4 +472,12 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     private fun persistSignatures() { val snapshot = signatures.toList(); executor.execute { signatureRepository.save(snapshot) } }
     private fun persistImportedFonts() { val snapshot = importedFonts.toList(); executor.execute { importedFontRepository.save(snapshot) } }
     override fun onCleared() { syncActive(); executor.shutdown(); super.onCleared() }
+}
+
+internal fun nextCharacterAfterSave(order: List<Int>, current: Int, drawn: Set<Int>): Int? {
+    if (order.isEmpty()) return null
+    val currentIndex = order.indexOf(current).takeIf { it >= 0 } ?: 0
+    val charactersAfterCurrent = order.drop(currentIndex + 1) + order.take(currentIndex + 1)
+    return charactersAfterCurrent.firstOrNull { it !in drawn }
+        ?: order[(currentIndex + 1) % order.size]
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -228,6 +228,7 @@ private fun SpacingControl(
 @Composable internal fun GlyphEditorScreen(
     codePoint: Int,
     initial: GlyphDrawing?,
+    defaultStrokeWidth: Float,
     drawings: Map<Int, GlyphDrawing>,
     characterOrder: List<Int>,
     pagingMode: Boolean,
@@ -245,14 +246,13 @@ private fun SpacingControl(
     var strokes by remember(codePoint) { mutableStateOf(initial?.strokes ?: emptyList()) }
     var active by remember(codePoint) { mutableStateOf<List<GlyphPoint>>(emptyList()) }
     var canvasSize by remember(codePoint) { mutableStateOf(initial?.let { it.canvasWidth to it.canvasHeight } ?: (1f to 1f)) }
-    var strokeWidth by remember { mutableFloatStateOf(initial?.strokeWidth ?: 8f) }
+    var strokeWidth by remember(codePoint) { mutableFloatStateOf(initial?.strokeWidth ?: defaultStrokeWidth) }
     var showDiscardDialog by remember { mutableStateOf(false) }
     var showMoreMenu by remember { mutableStateOf(false) }
     var showReference by remember { mutableStateOf(false) }
-    var showSavedConfirmation by remember(codePoint) { mutableStateOf(false) }
     var pendingNavigation by remember { mutableStateOf<(() -> Unit)?>(null) }
     var savedStrokes by remember(codePoint) { mutableStateOf(initial?.strokes ?: emptyList()) }
-    var savedStrokeWidth by remember(codePoint) { mutableFloatStateOf(initial?.strokeWidth ?: 8f) }
+    var savedStrokeWidth by remember(codePoint) { mutableFloatStateOf(initial?.strokeWidth ?: defaultStrokeWidth) }
     val strokesChanged = strokes != savedStrokes
     val thicknessChanged = strokes.isNotEmpty() && strokeWidth != savedStrokeWidth
     val isDirty = strokesChanged || thicknessChanged
@@ -294,17 +294,7 @@ private fun SpacingControl(
         savedStrokeWidth = strokeWidth
         when {
             pagingMode -> onSave(saved)
-            initial == null -> onSaveAndContinue(saved)
-            else -> {
-                onSaveAndStay(saved)
-                showSavedConfirmation = true
-            }
-        }
-    }
-    LaunchedEffect(showSavedConfirmation) {
-        if (showSavedConfirmation) {
-            kotlinx.coroutines.delay(1600)
-            showSavedConfirmation = false
+            else -> onSaveAndContinue(saved)
         }
     }
     Scaffold(
@@ -336,9 +326,6 @@ private fun SpacingControl(
     ) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
             if (!pagingMode) {
-                if (showSavedConfirmation) {
-                    Text("Saved ✓", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
-                }
                 BoxWithConstraints(Modifier.fillMaxWidth()) {
                     val centerPadding = ((maxWidth - 48.dp) / 2).coerceAtLeast(0.dp)
                     LazyRow(

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/TrueTypeGenerator.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/TrueTypeGenerator.kt
@@ -46,7 +46,7 @@ class TrueTypeGenerator {
         val contours = drawing.strokes.mapNotNull { stroke ->
             val source = stroke.points.map(::convert).distinct()
             if (source.size < 2) return@mapNotNull null
-            val radius = 55.0
+            val radius = glyphStrokeRadius(drawing.strokeWidth).toDouble()
             val left = ArrayList<P>()
             val right = ArrayList<P>()
             source.forEachIndexed { index, point ->
@@ -217,3 +217,7 @@ class TrueTypeGenerator {
         fun toByteArray() = data.toByteArray()
     }
 }
+
+/** Maps the editor's 2..24 thickness scale into TTF outline radius units. */
+internal fun glyphStrokeRadius(strokeWidth: Float): Float =
+    (55f * (strokeWidth / 8f)).coerceIn(14f, 165f)

--- a/app/src/test/java/com/jaafar/remoteconfig/fontcreator/CharacterSaveNavigationTest.kt
+++ b/app/src/test/java/com/jaafar/remoteconfig/fontcreator/CharacterSaveNavigationTest.kt
@@ -1,0 +1,29 @@
+package com.jaafar.remoteconfig.fontcreator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CharacterSaveNavigationTest {
+    private val order = listOf('A'.code, 'B'.code, 'C'.code)
+
+    @Test
+    fun `completed font advances to the next character`() {
+        assertEquals('B'.code, nextCharacterAfterSave(order, 'A'.code, order.toSet()))
+    }
+
+    @Test
+    fun `completed font wraps after the final character`() {
+        assertEquals('A'.code, nextCharacterAfterSave(order, 'C'.code, order.toSet()))
+    }
+
+    @Test
+    fun `incomplete font continues to the next missing character`() {
+        assertEquals('C'.code, nextCharacterAfterSave(order, 'A'.code, setOf('A'.code, 'B'.code)))
+    }
+
+    @Test
+    fun `empty character order closes the editor`() {
+        assertNull(nextCharacterAfterSave(emptyList(), 'A'.code, emptySet()))
+    }
+}

--- a/app/src/test/java/com/jaafar/remoteconfig/fontcreator/TrueTypeGeneratorThicknessTest.kt
+++ b/app/src/test/java/com/jaafar/remoteconfig/fontcreator/TrueTypeGeneratorThicknessTest.kt
@@ -1,0 +1,24 @@
+package com.jaafar.remoteconfig.fontcreator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TrueTypeGeneratorThicknessTest {
+    @Test
+    fun defaultThicknessPreservesExistingOutlineRadius() {
+        assertEquals(55f, glyphStrokeRadius(8f), 0f)
+    }
+
+    @Test
+    fun outlineRadiusScalesWithSavedThickness() {
+        assertTrue(glyphStrokeRadius(4f) < glyphStrokeRadius(8f))
+        assertTrue(glyphStrokeRadius(16f) > glyphStrokeRadius(8f))
+    }
+
+    @Test
+    fun outlineRadiusIsClampedToSafeFontBounds() {
+        assertEquals(14f, glyphStrokeRadius(0f), 0f)
+        assertEquals(165f, glyphStrokeRadius(100f), 0f)
+    }
+}


### PR DESCRIPTION
Follow-up to #190 and the subsequent font editor refinements.

- Removes the temporary `Saved ✓` confirmation from the letter editor
- Advances to the next character after saving an edited character
- Wraps from the final character to the first for completed fonts
- Preserves and exports the selected stroke thickness
- Keeps current Library fonts available in font selectors
- Adds regression tests for completed-font navigation and generated stroke thickness