### PR TITLE
Advance to the next character when editing completed fonts

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -220,7 +220,7 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         val currentIndex = order.indexOf(drawing.codePoint).coerceAtLeast(0)
         val charactersAfterCurrent = order.drop(currentIndex + 1) + order.take(currentIndex + 1)
         selectedCodePoint = charactersAfterCurrent.firstOrNull { it !in drawings }
-            ?: order.getOrNull(currentIndex + 1)
+            ?: order.takeIf { it.isNotEmpty() }?.get((currentIndex + 1) % order.size)
         isPagingMode = false
     }
 


### PR DESCRIPTION
Fixes completed-font editing so Save always advances to the next character and wraps from the final character to the first.

The temporary `Saved ✓` confirmation is already absent from the current `master`, so this PR introduces no unrelated UI or font-generation changes.