### PR TITLE
Add font rename to Font Workspace

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -122,6 +122,56 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         }
     }
 
+    fun renameActiveProject(name: String): Boolean {
+        val index = activeProjectIndex ?: return false
+        val current = projects.getOrNull(index) ?: return false
+        val clean = name.trim()
+        if (clean.isBlank()) { status = "Enter a name for the font."; return false }
+        val requestedStorageKey = normalizedFontStorageKey(clean)
+        if (requestedStorageKey.isBlank()) { status = "Use letters or numbers in the font name."; return false }
+        if (projects.withIndex().any { (projectIndex, project) ->
+                projectIndex != index && (project.name.equals(clean, ignoreCase = true) || normalizedFontStorageKey(project.name) == requestedStorageKey)
+            }) {
+            status = "A font with that name already exists."
+            return false
+        }
+        if (current.name == clean) return true
+
+        syncActive()
+        val renamed = projects[index].copy(name = clean)
+        projects[index] = renamed
+        persist()
+        if (referenceFontKey == current.name) setReferenceFont(clean)
+
+        val oldFile = generatedFile(current.name)
+        if (renamed.drawings.isEmpty()) {
+            oldFile.delete()
+            generatedFont = null
+            previewTypeface = null
+            status = "Font renamed."
+            return true
+        }
+
+        status = "Renaming font…"
+        executor.execute {
+            runCatching {
+                val newFile = generatedFile(renamed.name)
+                newFile.writeBytes(TrueTypeGenerator().generate(renamed.drawings, renamed.wordSpacingMm, renamed.letterSpacingMm, renamed.name))
+                newFile to loadTypeface(newFile)
+            }.onSuccess { (newFile, typeface) ->
+                if (oldFile != newFile) oldFile.delete()
+                main.post {
+                    generatedFont = newFile
+                    previewTypeface = typeface
+                    status = "Font renamed."
+                }
+            }.onFailure { error ->
+                main.post { status = "Font renamed, but its file could not be regenerated: ${error.message ?: "unknown error"}" }
+            }
+        }
+        return true
+    }
+
     fun openProject(index: Int) {
         val project = projects.getOrNull(index) ?: return
         activeProjectIndex = index; drawings.clear(); drawings.putAll(project.drawings.associateBy { it.codePoint })

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -69,8 +69,15 @@ import com.jaafar.remoteconfig.R
     val total = vm.activeCharacterOrder.size
     val drawn = vm.drawings.size
     val nextCode = vm.activeCharacterOrder.firstOrNull { it !in vm.drawings }
+    var showRenameDialog by remember { mutableStateOf(false) }
+    var renameName by remember(project?.name) { mutableStateOf(project?.name.orEmpty()) }
 
-    Text(project?.name.orEmpty(), style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(project?.name.orEmpty(), modifier = Modifier.weight(1f), style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+        IconButton(onClick = { renameName = project?.name.orEmpty(); showRenameDialog = true }) {
+            Icon(Icons.Filled.Edit, contentDescription = "Rename font")
+        }
+    }
     Text("Draw one letter at a time.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
     Surface(color = MaterialTheme.colorScheme.secondaryContainer, shape = RoundedCornerShape(14.dp)) {
         Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
@@ -118,6 +125,43 @@ import com.jaafar.remoteconfig.R
             Spacer(Modifier.width(8.dp))
             Text("Adjust spacing")
         }
+    }
+
+    if (showRenameDialog && project != null) {
+        val cleanName = renameName.trim()
+        val invalidName = cleanName.isNotEmpty() && normalizedFontStorageKey(cleanName).isBlank()
+        val duplicateName = vm.projects.withIndex().any { (index, candidate) ->
+            index != vm.activeProjectIndex && (candidate.name.equals(cleanName, ignoreCase = true) ||
+                normalizedFontStorageKey(candidate.name) == normalizedFontStorageKey(cleanName))
+        }
+        val unchangedName = cleanName == project.name
+        AlertDialog(
+            onDismissRequest = { showRenameDialog = false },
+            title = { Text("Rename font") },
+            text = {
+                OutlinedTextField(
+                    value = renameName,
+                    onValueChange = { renameName = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Font name") },
+                    singleLine = true,
+                    isError = invalidName || duplicateName,
+                    supportingText = {
+                        when {
+                            duplicateName -> Text("A font with that name already exists.")
+                            invalidName -> Text("Use letters or numbers in the font name.")
+                        }
+                    },
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = { if (vm.renameActiveProject(renameName)) showRenameDialog = false },
+                    enabled = cleanName.isNotEmpty() && !invalidName && !duplicateName && !unchangedName,
+                ) { Text("Rename") }
+            },
+            dismissButton = { TextButton(onClick = { showRenameDialog = false }) { Text("Cancel") } },
+        )
     }
 }
 


### PR DESCRIPTION
Adds a low-click rename action beside the font name in Font Workspace.

- Opens a prefilled Rename Font dialog from a pencil icon
- Rejects blank, invalid, and duplicate names
- Preserves drawings, spacing, and language settings
- Regenerates the TTF with the new internal font name
- Removes the old generated font file after successful regeneration
- Keeps the selected reference-font setting in sync when that font is renamed