### PR TITLE
Clarify the first-time font naming prompt

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
@@ -122,7 +122,7 @@ import com.jaafar.remoteconfig.R
                 keyboardController?.show()
             }
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Next, you will start drawing your letters. You can return and continue any time.")
+                Text("Give your font a name. You can change it later.")
                 OutlinedTextField(
                     name,
                     { name = it },


### PR DESCRIPTION
Replaces the forward-looking drawing explanation in the Create Font dialog with concise, task-focused copy:

> Give your font a name. You can change it later.

The customer still proceeds directly to the drawing screen after creating the font.