### PR TITLE
Refine dashboard actions and drawing progress

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/DashboardScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/DashboardScreen.kt
@@ -56,31 +56,31 @@ internal fun DashboardScreen(
         )
         unfinishedIndex != null -> {
             val project = vm.projects[unfinishedIndex]
+            val total = vm.characterCount(project).coerceAtLeast(1)
+            val percentage = (project.drawings.size * 100 / total).coerceIn(0, 100)
             DashboardHero(
-                title = "Continue drawing",
-                detail = "${project.name} · ${project.drawings.size} of ${vm.characterCount(project)} characters",
+                title = "Continue ${project.name}",
+                detail = "$percentage% complete · Nice progress—keep going!",
                 icon = Icons.Filled.Edit,
                 click = { continueFont(unfinishedIndex) },
             )
         }
-        preferredFont != null -> DashboardHero(
-            title = "Use your font on an image",
-            detail = preferredFont,
+    }
+
+    if (preferredFont != null) {
+        DashboardRowAction(
+            title = "Use font on image",
+            detail = "Write with $preferredFont on a photo",
             icon = Icons.Filled.Image,
             click = { useFontOnImage(preferredFont) },
         )
     }
-
-    OutlinedCard(Modifier.fillMaxWidth().clickable(onClick = openFillMark)) {
-        Row(Modifier.fillMaxWidth().padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
-            Icon(Icons.Filled.Description, contentDescription = null)
-            Spacer(Modifier.width(12.dp))
-            Column {
-                Text("Fill & Mark", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-                Text("Add text, signatures, or stamps to a document", style = MaterialTheme.typography.bodySmall)
-            }
-        }
-    }
+    DashboardRowAction(
+        title = "Fill & Mark",
+        detail = "Add text, signatures, or stamps to a document",
+        icon = Icons.Filled.Description,
+        click = openFillMark,
+    )
 
     Text("Your assets", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
     val assets = listOf(
@@ -106,6 +106,20 @@ internal fun DashboardScreen(
                     Text(action.title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
                     Text(action.detail, style = MaterialTheme.typography.labelSmall)
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DashboardRowAction(title: String, detail: String, icon: ImageVector, click: () -> Unit) {
+    OutlinedCard(Modifier.fillMaxWidth().clickable(onClick = click)) {
+        Row(Modifier.fillMaxWidth().padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(icon, contentDescription = null)
+            Spacer(Modifier.width(12.dp))
+            Column {
+                Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(detail, style = MaterialTheme.typography.bodySmall)
             }
         }
     }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Undo
+import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -127,7 +128,11 @@ import com.jaafar.remoteconfig.R
     }
 
     if (drawn > 0) {
-        TextButton(onClick = { vm.generate(); preview() }, modifier = Modifier.fillMaxWidth()) { Text("Preview font") }
+        OutlinedButton(onClick = { vm.generate(); preview() }, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Filled.Visibility, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text("Preview font")
+        }
     }
 
     if (drawn > 0) {


### PR DESCRIPTION
Follow-up to merged PR #203, created from the latest `master`.

- Makes **Use font on image** a standalone left-aligned control matching **Fill & Mark**
- Shows completion percentage and encouraging copy on **Continue drawing**
- Changes **Preview font** from floating centered text to a consistent outlined button with an icon

This PR contains only these follow-up refinements.