### PR TITLE
Finish font creation after the final character

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -273,14 +273,13 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     }
 
     fun saveDrawingAndContinue(drawing: GlyphDrawing) {
+        val wasExisting = drawing.codePoint in drawings
         lastStrokeWidth = drawing.strokeWidth
         drawings[drawing.codePoint] = drawing
         syncActive(); persist(); status = "Letter saved."
         val order = activeCharacterOrder
-        val currentIndex = order.indexOf(drawing.codePoint).coerceAtLeast(0)
-        val charactersAfterCurrent = order.drop(currentIndex + 1) + order.take(currentIndex + 1)
-        selectedCodePoint = charactersAfterCurrent.firstOrNull { it !in drawings }
-            ?: order.takeIf { it.isNotEmpty() }?.get((currentIndex + 1) % order.size)
+        selectedCodePoint = characterAfterSave(order, drawing.codePoint, drawings.keys, wasExisting)
+        if (selectedCodePoint == null && !wasExisting) status = "Your font is ready."
         isPagingMode = false
     }
 
@@ -535,4 +534,13 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     private fun persistSignatures() { val snapshot = signatures.toList(); executor.execute { signatureRepository.save(snapshot) } }
     private fun persistImportedFonts() { val snapshot = importedFonts.toList(); executor.execute { importedFontRepository.save(snapshot) } }
     override fun onCleared() { syncActive(); executor.shutdown(); super.onCleared() }
+}
+
+internal fun characterAfterSave(order: List<Int>, current: Int, drawn: Set<Int>, wasExisting: Boolean): Int? {
+    if (order.isEmpty()) return null
+    if (!wasExisting && order.all { it in drawn }) return null
+    val currentIndex = order.indexOf(current).takeIf { it >= 0 } ?: 0
+    val charactersAfterCurrent = order.drop(currentIndex + 1) + order.take(currentIndex + 1)
+    return charactersAfterCurrent.firstOrNull { it !in drawn }
+        ?: order[(currentIndex + 1) % order.size]
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -114,7 +114,12 @@ import com.jaafar.remoteconfig.R
             Text("Use this font on an image")
         }
     } else {
-        Text("Your letter set is complete.", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text("Your font is ready!", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+        Text(
+            "You completed all characters. Now put your handwriting to use.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
         Button(onClick = useCurrentFont, modifier = Modifier.fillMaxWidth()) {
             Icon(Icons.Filled.Image, contentDescription = null)
             Spacer(Modifier.width(8.dp))
@@ -342,8 +347,9 @@ private fun SpacingControl(
         }
     }
     val isLastInQueue = pagingProgress != null && pagingProgress.first == pagingProgress.second
+    val isFinalMissingCharacter = initial == null && codePoint !in drawings && characterOrder.count { it !in drawings } == 1
     val saveLabel = when {
-        isLastInQueue -> "Save & Finish"
+        isLastInQueue || isFinalMissingCharacter -> "Save & Finish"
         pagingMode -> "Save & Next"
         else -> "Save"
     }

--- a/app/src/test/java/com/jaafar/remoteconfig/fontcreator/FontCompletionNavigationTest.kt
+++ b/app/src/test/java/com/jaafar/remoteconfig/fontcreator/FontCompletionNavigationTest.kt
@@ -1,0 +1,29 @@
+package com.jaafar.remoteconfig.fontcreator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FontCompletionNavigationTest {
+    private val order = listOf('A'.code, 'B'.code, 'C'.code)
+
+    @Test
+    fun `saving the final missing character finishes creation`() {
+        assertNull(characterAfterSave(order, 'C'.code, order.toSet(), wasExisting = false))
+    }
+
+    @Test
+    fun `editing a completed font advances normally`() {
+        assertEquals('B'.code, characterAfterSave(order, 'A'.code, order.toSet(), wasExisting = true))
+    }
+
+    @Test
+    fun `editing the final character wraps to the first`() {
+        assertEquals('A'.code, characterAfterSave(order, 'C'.code, order.toSet(), wasExisting = true))
+    }
+
+    @Test
+    fun `creation continues to another missing character`() {
+        assertEquals('C'.code, characterAfterSave(order, 'A'.code, setOf('A'.code, 'B'.code), wasExisting = false))
+    }
+}


### PR DESCRIPTION
## Summary
- finish font creation after saving the final previously missing character instead of wrapping to A
- return customers to a clear completed Font Workspace state with a primary “Use this font on an image” action
- keep Edit Letters behavior unchanged: saving an existing character advances to the next character and wraps after the final one
- label the final creation action “Save & Finish”

## Flow distinction
- **Creation:** the current character did not exist before Save, and saving it completes the required set → close the canvas and show the completed workspace
- **Editing:** the character already existed before Save → stay in the editor journey and advance normally

## Tests
- added unit coverage for final-character completion, continued creation, normal edit advancement, and edit wraparound
- `git diff --check` passes
- local Gradle is unavailable; GitHub Actions will run `:app:testDebugUnitTest`