### PR TITLE
Add Phrase Mode to letter drawing

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -153,6 +153,18 @@ fun FontCreatorApp(
                 pagingProgress = viewModel.pagingProgress,
                 canGoPrevious = viewModel.canGoToPreviousLetter,
                 referenceTypeface = referenceTypeface,
+                phraseModeEnabled = viewModel.phraseModeEnabled,
+                phraseText = viewModel.lastPhrase,
+                onCreatePhrase = { phrase ->
+                    if (viewModel.startPhrase(phrase)) {
+                        previewText = phrase.trim()
+                        preferences.edit().putString("preview_text", previewText).apply()
+                        true
+                    } else {
+                        false
+                    }
+                },
+                onDisablePhrase = viewModel::disablePhraseMode,
                 onCancel = viewModel::closeEditor,
                 onPrevious = viewModel::previousLetter,
                 onSelectCharacter = viewModel::edit,
@@ -231,7 +243,7 @@ fun FontCreatorApp(
                     adjustSpacing = { screen = Screen.Spacing },
                     useOnImage = { fontName ->
                         preferredImageFontName = fontName
-                        initialImageText = ""
+                        initialImageText = previewText
                         autoPickImage = true
                         screen = Screen.Image
                     },

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -24,6 +24,8 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     companion object {
         private const val PREFS_DEFAULT_SIGNATURE = "default_signature_name"
         private const val PREFS_DEFAULT_STAMP = "default_stamp_name"
+        private const val PREFS_PHRASE_MODE = "phrase_mode_enabled"
+        private const val PREFS_LAST_PHRASE = "last_phrase"
         val CHARACTER_ORDER: List<Int> = buildList {
             addAll('A'.code..'Z'.code); addAll('a'.code..'z'.code); addAll('0'.code..'9'.code)
             " .,!?\'\"-:;()".forEach { add(it.code) }; addAll((33..126).filter { it !in this })
@@ -81,6 +83,8 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     var defaultStampName by mutableStateOf(prefs.getString(PREFS_DEFAULT_STAMP, null)); private set
     var lastEditedCodePoint by mutableStateOf<Int?>(null); private set
     var lastStrokeWidth by mutableFloatStateOf(8f); private set
+    var phraseModeEnabled by mutableStateOf(prefs.getBoolean(PREFS_PHRASE_MODE, false)); private set
+    var lastPhrase by mutableStateOf(prefs.getString(PREFS_LAST_PHRASE, "") ?: ""); private set
 
     /** Returns all available typefaces (generated + imported) with their display labels. */
     fun hasGeneratedFont(name: String): Boolean = generatedFile(name).exists()
@@ -219,6 +223,46 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     }
 
     fun startPaging() = startQueue(activeCharacterOrder.filter { it !in drawings }, "All supported characters have already been drawn.")
+
+    fun startPhrase(phrase: String): Boolean {
+        val cleanPhrase = phrase.trim()
+        if (cleanPhrase.isBlank()) {
+            status = "Enter a phrase first."
+            return false
+        }
+        val phraseCharacters = applicablePhraseCodePoints(cleanPhrase, activeCharacterOrder.toSet())
+        if (phraseCharacters.isEmpty()) {
+            status = "The phrase has no characters supported by the selected languages."
+            return false
+        }
+        lastPhrase = cleanPhrase
+        phraseModeEnabled = true
+        prefs.edit()
+            .putString(PREFS_LAST_PHRASE, cleanPhrase)
+            .putBoolean(PREFS_PHRASE_MODE, true)
+            .apply()
+        val missingCharacters = phraseCharacters.filter { it !in drawings }
+        if (missingCharacters.isEmpty()) {
+            closeEditor()
+            phraseModeEnabled = false
+            prefs.edit().putBoolean(PREFS_PHRASE_MODE, false).apply()
+            status = "Phrase ready — all required characters are already available."
+        } else {
+            startQueue(missingCharacters, "Phrase ready — all required characters are already available.")
+        }
+        return true
+    }
+
+    fun disablePhraseMode() {
+        phraseModeEnabled = false
+        prefs.edit().putBoolean(PREFS_PHRASE_MODE, false).apply()
+        if (isPagingMode) {
+            isPagingMode = false
+            pagingQueue = emptyList()
+            pagingHistory = emptyList()
+        }
+    }
+
     private fun startQueue(queue: List<Int>, emptyMessage: String) {
         if (queue.isEmpty()) { status = emptyMessage; return }
         pagingQueue = queue
@@ -268,8 +312,13 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
             pagingQueue = pagingQueue.filterNot { it == drawing.codePoint }
         }
         selectedCodePoint = if (isPagingMode && pagingQueue.isNotEmpty()) pagingQueue.first() else null
+        val phraseFinished = selectedCodePoint == null && phraseModeEnabled
         if (selectedCodePoint == null) isPagingMode = false
-        syncActive(); persist(); status = "Glyph saved."
+        if (phraseFinished) {
+            phraseModeEnabled = false
+            prefs.edit().putBoolean(PREFS_PHRASE_MODE, false).apply()
+        }
+        syncActive(); persist(); status = if (phraseFinished) "Phrase ready." else "Glyph saved."
     }
 
     fun saveDrawingAndContinue(drawing: GlyphDrawing) {
@@ -535,6 +584,9 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     private fun persistImportedFonts() { val snapshot = importedFonts.toList(); executor.execute { importedFontRepository.save(snapshot) } }
     override fun onCleared() { syncActive(); executor.shutdown(); super.onCleared() }
 }
+
+internal fun applicablePhraseCodePoints(phrase: String, supported: Set<Int>): List<Int> =
+    phrase.codePoints().toArray().toList().distinct().filter { it != 0x20 && it in supported }
 
 internal fun characterAfterSave(order: List<Int>, current: Int, drawn: Set<Int>, wasExisting: Boolean): Int? {
     if (order.isEmpty()) return null

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -300,6 +300,10 @@ private fun SpacingControl(
     pagingProgress: Pair<Int, Int>?,
     canGoPrevious: Boolean,
     referenceTypeface: Typeface,
+    phraseModeEnabled: Boolean,
+    phraseText: String,
+    onCreatePhrase: (String) -> Boolean,
+    onDisablePhrase: () -> Unit,
     onCancel: () -> Unit,
     onPrevious: () -> Unit,
     onSelectCharacter: (Int) -> Unit,
@@ -314,6 +318,8 @@ private fun SpacingControl(
     var strokeWidth by remember(codePoint) { mutableFloatStateOf(initial?.strokeWidth ?: defaultStrokeWidth) }
     var showDiscardDialog by remember { mutableStateOf(false) }
     var showMoreMenu by remember { mutableStateOf(false) }
+    var showPhraseDialog by remember { mutableStateOf(false) }
+    var phraseDraft by remember(phraseText) { mutableStateOf(phraseText) }
     var showReference by remember { mutableStateOf(false) }
     var pendingNavigation by remember { mutableStateOf<(() -> Unit)?>(null) }
     var savedStrokes by remember(codePoint) { mutableStateOf(initial?.strokes ?: emptyList()) }
@@ -384,6 +390,19 @@ private fun SpacingControl(
                             text = { Text("Reference letter") },
                             trailingIcon = { Checkbox(checked = showReference, onCheckedChange = null) },
                             onClick = { showReference = !showReference; showMoreMenu = false },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Phrase mode") },
+                            trailingIcon = { Checkbox(checked = phraseModeEnabled, onCheckedChange = null) },
+                            onClick = {
+                                showMoreMenu = false
+                                if (phraseModeEnabled) {
+                                    onDisablePhrase()
+                                } else {
+                                    phraseDraft = phraseText
+                                    showPhraseDialog = true
+                                }
+                            },
                         )
                     }
                 }
@@ -517,6 +536,36 @@ private fun SpacingControl(
                 }
             }
         }
+    }
+    if (showPhraseDialog) {
+        AlertDialog(
+            onDismissRequest = { showPhraseDialog = false },
+            title = { Text("Phrase mode") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Enter the text you want to create. Only its supported missing characters will be shown.")
+                    OutlinedTextField(
+                        value = phraseDraft,
+                        onValueChange = { phraseDraft = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("Phrase") },
+                        minLines = 3,
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        val createPhrase = {
+                            if (onCreatePhrase(phraseDraft)) showPhraseDialog = false
+                        }
+                        navigateSafely(createPhrase)
+                    },
+                    enabled = phraseDraft.isNotBlank(),
+                ) { Text("Create phrase") }
+            },
+            dismissButton = { TextButton(onClick = { showPhraseDialog = false }) { Text("Cancel") } },
+        )
     }
     if (showDiscardDialog) ModalBottomSheet(onDismissRequest = { showDiscardDialog = false; pendingNavigation = null }) {
         Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/test/java/com/jaafar/remoteconfig/fontcreator/PhraseModeTest.kt
+++ b/app/src/test/java/com/jaafar/remoteconfig/fontcreator/PhraseModeTest.kt
@@ -1,0 +1,24 @@
+package com.jaafar.remoteconfig.fontcreator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PhraseModeTest {
+    @Test
+    fun phraseCharactersAreUniqueSupportedAndOrdered() {
+        val supported = setOf('H'.code, 'e'.code, 'l'.code, 'o'.code, '!'.code)
+
+        val result = applicablePhraseCodePoints("Hello, Hello!", supported)
+
+        assertEquals(listOf('H'.code, 'e'.code, 'l'.code, 'o'.code, '!'.code), result)
+    }
+
+    @Test
+    fun phraseCharactersIgnoreSpacesAndUnsupportedCharacters() {
+        val supported = setOf('A'.code, '1'.code)
+
+        val result = applicablePhraseCodePoints(" A🙂1 ", supported)
+
+        assertEquals(listOf('A'.code, '1'.code), result)
+    }
+}


### PR DESCRIPTION
## Summary
- add a checked Phrase Mode option to the drawing screen overflow menu
- persist and prefill the last phrase
- draw only unique, supported, missing characters from the phrase
- reuse the existing paging flow so the final glyph shows **Save & Finish** and returns to the font workspace
- seed preview, spacing, and image text with the phrase
- keep Edit Letters on the full selected character set

## Edge cases
- spaces are ignored
- unsupported characters are filtered out
- phrases whose glyphs already exist return directly to the workspace
- Phrase Mode turns off after completion while retaining the phrase for next time

## Tests
- added unit coverage for ordered de-duplication and unsupported/space filtering