### PR TITLE
Keep Phrase Mode in the standard letter editor

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -148,7 +148,7 @@ fun FontCreatorApp(
                 initial = viewModel.drawings[viewModel.selectedCodePoint],
                 defaultStrokeWidth = viewModel.lastStrokeWidth,
                 drawings = viewModel.drawings,
-                characterOrder = viewModel.activeCharacterOrder,
+                characterOrder = viewModel.editorCharacterOrder,
                 pagingMode = viewModel.isPagingMode,
                 pagingProgress = viewModel.pagingProgress,
                 canGoPrevious = viewModel.canGoToPreviousLetter,

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -45,6 +45,12 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         return letters + digits + symbols
     }
 
+    val phraseCharacterOrder: List<Int>
+        get() = applicablePhraseCodePoints(lastPhrase, activeCharacterOrder.toSet())
+
+    val editorCharacterOrder: List<Int>
+        get() = if (phraseModeEnabled) phraseCharacterOrder else activeCharacterOrder
+
     fun characterCount(project: FontProject): Int = project.selectedLanguages
         .flatMap { it.codePoints }
         .distinct()

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -338,6 +338,7 @@ private fun SpacingControl(
     val char = codePoint.toChar().toString()
     val title = "Draw $char"
     val characterIndex = characterOrder.indexOf(codePoint)
+    val completedCharacterCount = characterOrder.count { it in drawings }
     val letterBarState = rememberLazyListState()
     LaunchedEffect(codePoint, characterOrder) {
         if (characterIndex >= 0) {
@@ -372,7 +373,7 @@ private fun SpacingControl(
     Scaffold(
         topBar = {
             AppTopBar(title, handleBack) {
-                if (pagingMode && canGoPrevious) {
+                if (pagingMode && !phraseModeEnabled && canGoPrevious) {
                     OutlinedButton(
                         onClick = onPrevious,
                         modifier = Modifier
@@ -410,7 +411,7 @@ private fun SpacingControl(
         },
     ) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-            if (!pagingMode) {
+            if (!pagingMode || phraseModeEnabled) {
                 BoxWithConstraints(Modifier.fillMaxWidth()) {
                     val centerPadding = ((maxWidth - 48.dp) / 2).coerceAtLeast(0.dp)
                     LazyRow(
@@ -452,14 +453,14 @@ private fun SpacingControl(
             }
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    "${drawings.size} / ${characterOrder.size} completed",
+                    "$completedCharacterCount / ${characterOrder.size} completed",
                     modifier = Modifier.weight(1f),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
             LinearProgressIndicator(
-                progress = if (characterOrder.isEmpty()) 0f else (drawings.size.toFloat() / characterOrder.size).coerceIn(0f, 1f),
+                progress = if (characterOrder.isEmpty()) 0f else (completedCharacterCount.toFloat() / characterOrder.size).coerceIn(0f, 1f),
                 modifier = Modifier.fillMaxWidth().height(3.dp),
             )
             Spacer(Modifier.height(4.dp))
@@ -530,7 +531,7 @@ private fun SpacingControl(
                 IconButton({ strokes = emptyList(); active = emptyList() }, enabled = strokes.isNotEmpty()) {
                     Icon(Icons.Default.Clear, contentDescription = "Clear")
                 }
-                if (pagingMode) TextButton(onSkip) { Text("Skip") }
+                if (pagingMode && !phraseModeEnabled) TextButton(onSkip) { Text("Skip") }
                 Button(savePrimary, Modifier.weight(1f), enabled = strokes.isNotEmpty() && (isDirty || initial == null || pagingMode)) {
                     Text(saveLabel, maxLines = 1)
                 }


### PR DESCRIPTION
## Correction
Phrase Mode now uses the same drawing-screen layout as normal letter editing.

- the horizontal letter strip stays visible
- the strip contains only the phrase’s unique supported characters
- existing drawings appear in their phrase tiles
- progress counts only completed phrase characters
- paging-only Previous and Skip controls stay hidden
- Save & Next / Save & Finish behavior is preserved