### PR TITLE
Open all-letter editor from font preview

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -228,7 +228,10 @@ fun FontCreatorApp(
                     changePreviewText = { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() },
                     back = { screen = Screen.Letters },
                     editLetters = { screen = Screen.Letters },
-                    startDrawing = viewModel::startPaging,
+                    startDrawing = {
+                        screen = Screen.Letters
+                        viewModel.editLetters()
+                    },
                     useOnImage = { fontName, text ->
                         preferredImageFontName = fontName
                         initialImageText = text


### PR DESCRIPTION
## Fix
**Try your font → Continue drawing** now opens the normal all-letter drawing screen:

- full selected-language letter bar
- full alphabet progress
- standard direct letter editing

It no longer opens the missing-letter paging queue. Phrase Mode remains limited to the explicit three-dot menu option.