### PR TITLE
Make Android back follow in-app navigation

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FeatureTutorialScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FeatureTutorialScreen.kt
@@ -1,5 +1,6 @@
 package com.jaafar.remoteconfig.fontcreator
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -25,6 +26,9 @@ internal fun FeatureTutorial(onFinished: () -> Unit) {
     )
     var pageIndex by remember { mutableIntStateOf(0) }
     val page = pages[pageIndex]
+    BackHandler {
+        if (pageIndex > 0) pageIndex-- else onFinished()
+    }
     Scaffold { padding ->
         Column(
             Modifier.fillMaxSize().padding(padding).padding(24.dp),

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -298,6 +298,7 @@ fun FontCreatorApp(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable internal fun Page(title: String, back: (() -> Unit)? = null, scrollable: Boolean = false, actions: @Composable RowScope.() -> Unit = {}, content: @Composable ColumnScope.() -> Unit) {
+    BackHandler(enabled = back != null) { back?.invoke() }
     Scaffold(topBar = { AppTopBar(title, back, actions) }) { padding ->
         val scrollModifier = if (scrollable) Modifier.verticalScroll(rememberScrollState()) else Modifier
         Column(

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -7,6 +7,7 @@ import android.graphics.Paint
 import android.graphics.Typeface
 import android.net.Uri
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Canvas as ComposeCanvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -74,6 +75,7 @@ fun ImageTextEditorScreen(imageUri: Uri, typeface: Typeface, initialText: String
     var textPosition by remember { mutableStateOf(Offset(.5f, .85f)) }
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
 
+    BackHandler(onBack = onBack)
     Scaffold(topBar = { AppTopBar("Write on image", onBack) }) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
             if (bitmap == null) {


### PR DESCRIPTION
## Behavior
- Android back now invokes the same callback as the top-left back icon on every shared app page
- Home remains the only screen where Android back is unhandled, so it closes the app normally
- the custom image text editor now returns to its previous app screen instead of closing the activity
- onboarding goes to its previous page, or enters Home from its first page
- existing unsaved-letter confirmation and signature subpage handling remain intact

## Result
Screen cleanup callbacks now run consistently regardless of whether the customer taps the app icon or uses Android back.