### PR TITLE
Add combined Fine-tune your font screen

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -84,7 +84,7 @@ private val ModernDarkColors = darkColorScheme(
     outlineVariant = Color(0xFF45464F),
 )
 
-internal enum class Screen { Home, Fonts, Signatures, Stamps, FontReady, Letters, Spacing, Image, Signature, FillMark, Settings }
+internal enum class Screen { Home, Fonts, Signatures, Stamps, FontReady, Letters, Image, Signature, FillMark, Settings }
 
 @Composable
 fun FontCreatorApp(
@@ -169,8 +169,20 @@ fun FontCreatorApp(
                 onPrevious = viewModel::previousLetter,
                 onSelectCharacter = viewModel::edit,
                 onSkip = viewModel::skipLetter,
-                onSave = viewModel::saveDrawing,
-                onSaveAndContinue = viewModel::saveDrawingAndContinue,
+                onSave = { drawing ->
+                    viewModel.saveDrawing(drawing)
+                    if (viewModel.selectedCodePoint == null) {
+                        viewModel.generate()
+                        screen = Screen.FontReady
+                    }
+                },
+                onSaveAndContinue = { drawing ->
+                    viewModel.saveDrawingAndContinue(drawing)
+                    if (viewModel.selectedCodePoint == null) {
+                        viewModel.generate()
+                        screen = Screen.FontReady
+                    }
+                },
                 onSaveAndStay = viewModel::saveDrawingAndStay,
             )
             else -> {
@@ -227,7 +239,6 @@ fun FontCreatorApp(
                     previewText = previewText,
                     changePreviewText = { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() },
                     back = { screen = Screen.Letters },
-                    editLetters = { screen = Screen.Letters },
                     startDrawing = {
                         screen = Screen.Letters
                         viewModel.editLetters()
@@ -242,8 +253,10 @@ fun FontCreatorApp(
                 Screen.Letters -> LettersScreen(
                     vm = viewModel,
                     back = { screen = fontWorkspaceBack },
-                    preview = { screen = Screen.FontReady },
-                    adjustSpacing = { screen = Screen.Spacing },
+                    fineTune = {
+                        viewModel.generate()
+                        screen = Screen.FontReady
+                    },
                     useOnImage = { fontName ->
                         preferredImageFontName = fontName
                         initialImageText = previewText
@@ -251,7 +264,6 @@ fun FontCreatorApp(
                         screen = Screen.Image
                     },
                 )
-                Screen.Spacing -> SpacingScreen(viewModel, previewText, { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() }) { screen = Screen.Letters }
                 Screen.Image -> ImageScreen(
                     vm = viewModel,
                     back = { preferredImageFontName = null; initialImageText = ""; autoPickImage = false; screen = Screen.Home },

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -59,8 +59,7 @@ import com.jaafar.remoteconfig.R
 @Composable internal fun LettersScreen(
     vm: FontCreatorViewModel,
     back: () -> Unit,
-    preview: () -> Unit,
-    adjustSpacing: () -> Unit,
+    fineTune: () -> Unit,
     useOnImage: (String) -> Unit,
 ) = Page("Font workspace", back, actions = {
     val file = vm.generatedFont
@@ -133,18 +132,10 @@ import com.jaafar.remoteconfig.R
     }
 
     if (drawn > 0) {
-        OutlinedButton(onClick = { vm.generate(); preview() }, modifier = Modifier.fillMaxWidth()) {
-            Icon(Icons.Filled.Visibility, contentDescription = null)
-            Spacer(Modifier.width(8.dp))
-            Text("Preview font")
-        }
-    }
-
-    if (drawn > 0) {
-        OutlinedButton(onClick = adjustSpacing, modifier = Modifier.fillMaxWidth()) {
+        OutlinedButton(onClick = fineTune, modifier = Modifier.fillMaxWidth()) {
             Icon(Icons.Filled.Tune, contentDescription = null)
             Spacer(Modifier.width(8.dp))
-            Text("Adjust spacing")
+            Text("Fine-tune your font")
         }
     }
 
@@ -269,7 +260,7 @@ internal fun SpacingScreen(
 }
 
 @Composable
-private fun SpacingControl(
+internal fun SpacingControl(
     label: String,
     value: Float,
     step: Float,

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
@@ -58,34 +58,85 @@ import com.jaafar.remoteconfig.R
     previewText: String,
     changePreviewText: (String) -> Unit,
     back: () -> Unit,
-    editLetters: () -> Unit,
     startDrawing: () -> Unit,
     useOnImage: (String, String) -> Unit,
 ) {
     val project = vm.activeProject
     if (project == null) {
-        Page("Font preview", back) { Text("Choose a handwriting font first.") }
+        Page("Fine-tune your font", back) { Text("Choose a handwriting font first.") }
         return
     }
+    val context = LocalContext.current
     val requiredCharacters = vm.activeCharacterOrder.toSet()
-    val total = requiredCharacters.size
     val drawnCodePoints = project.drawings.map { it.codePoint }.toSet()
     val drawn = drawnCodePoints.intersect(requiredCharacters).size
     val complete = requiredCharacters.isNotEmpty() && requiredCharacters.all { it in drawnCodePoints }
-    Page(if (complete) "Your font" else "Try your font", back, scrollable = true) {
+    var letterSpacing by remember(project.name) { mutableFloatStateOf(project.letterSpacingMm) }
+    var wordSpacing by remember(project.name) { mutableFloatStateOf(project.wordSpacingMm) }
+    val updateSpacing: (Float, Float) -> Unit = { nextLetter, nextWord ->
+        letterSpacing = nextLetter
+        wordSpacing = nextWord
+        if (vm.setSpacing(nextLetter.toString(), nextWord.toString())) vm.generate()
+    }
+
+    Page("Fine-tune your font", back, scrollable = true) {
         Text(project.name, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
         if (vm.previewTypeface == null) {
             Text("Creating your font…", color = MaterialTheme.colorScheme.onSurfaceVariant)
             LinearProgressIndicator(Modifier.fillMaxWidth())
             Text("Turning $drawn drawn letters into a usable font preview.", style = MaterialTheme.typography.bodySmall)
         } else {
-            Surface(color = MaterialTheme.colorScheme.secondaryContainer, contentColor = MaterialTheme.colorScheme.onSecondaryContainer, shape = RoundedCornerShape(12.dp)) {
-                Text(if (complete) "FONT FILE READY" else "$drawn LETTERS INCLUDED", modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+            Surface(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Text(
+                    if (complete) "FONT FILE READY" else "$drawn LETTERS INCLUDED",
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                )
             }
-            Text(if (complete) "Your font is ready to use." else "Your preview uses the letters you have drawn so far.", color = MaterialTheme.colorScheme.onSurfaceVariant)
-            OutlinedTextField(value = previewText, onValueChange = changePreviewText, modifier = Modifier.fillMaxWidth(), label = { Text("Try typing with your font") }, minLines = 3, textStyle = MaterialTheme.typography.headlineMedium.copy(fontFamily = FontFamily(vm.previewTypeface!!)))
-            Button(onClick = { useOnImage(project.name, previewText) }, modifier = Modifier.fillMaxWidth()) { Text("Use on an image") }
-            if (!complete) OutlinedButton(onClick = startDrawing, modifier = Modifier.fillMaxWidth()) { Text("Continue drawing") }
+            Text(
+                if (complete) "Your font is ready to use." else "Preview and adjust the letters you have drawn so far.",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = previewText,
+                onValueChange = changePreviewText,
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Preview text") },
+                minLines = 3,
+                textStyle = MaterialTheme.typography.headlineMedium.copy(fontFamily = FontFamily(vm.previewTypeface!!)),
+            )
+            Text("Spacing", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            SpacingControl(label = "Letter spacing", value = letterSpacing, step = 0.25f, min = -3f, max = 10f) {
+                updateSpacing(it, wordSpacing)
+            }
+            SpacingControl(label = "Word spacing", value = wordSpacing, step = 0.5f, min = 0.2f, max = 50f) {
+                updateSpacing(letterSpacing, it)
+            }
+            Text("Spacing changes are saved automatically.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Button(onClick = { useOnImage(project.name, previewText) }, modifier = Modifier.fillMaxWidth()) {
+                Text("Use on an image")
+            }
+            OutlinedButton(onClick = startDrawing, modifier = Modifier.fillMaxWidth()) {
+                Text("Continue drawing")
+            }
+            vm.generatedFont?.let { file ->
+                OutlinedButton(
+                    onClick = {
+                        val uri = FileProvider.getUriForFile(context, "${context.packageName}.files", file)
+                        context.startActivity(Intent.createChooser(Intent(Intent.ACTION_SEND).apply {
+                            type = "font/ttf"
+                            putExtra(Intent.EXTRA_STREAM, uri)
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }, "Share ${project.name}"))
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Share font file") }
+            }
         }
         if (vm.status.isNotBlank()) Text(vm.status, style = MaterialTheme.typography.bodySmall)
     }


### PR DESCRIPTION
## Journey
- replace separate **Preview font** and **Adjust spacing** workspace actions with **Fine-tune your font**
- route every final **Save & Finish** directly to Fine-tune after generating the font
- keep Back navigation pointed at the font workspace

## Fine-tune options
- editable preview text, prefilled with the Phrase Mode phrase
- live letter-spacing controls
- live word-spacing controls
- Use on an image
- Continue drawing
- Share font file

Spacing changes save automatically and regenerate the preview.