### PR TITLE
Polish Fine-tune spacing controls

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -268,29 +268,27 @@ internal fun SpacingControl(
     max: Float,
     change: (Float) -> Unit,
 ) {
-    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(label, style = MaterialTheme.typography.titleMedium)
-        Row(
-            Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.End,
-        ) {
-            OutlinedButton(
-                onClick = { change((value - step).coerceAtLeast(min)) },
-                modifier = Modifier.width(56.dp),
-                contentPadding = PaddingValues(0.dp),
-                enabled = value > min,
-            ) { Text("−") }
-            Box(Modifier.width(96.dp), contentAlignment = Alignment.Center) {
-                Text("${String.format(java.util.Locale.US, "%.2f", value)} mm", style = MaterialTheme.typography.titleMedium)
-            }
-            OutlinedButton(
-                onClick = { change((value + step).coerceAtMost(max)) },
-                modifier = Modifier.width(56.dp),
-                contentPadding = PaddingValues(0.dp),
-                enabled = value < max,
-            ) { Text("+") }
+    Row(
+        Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.titleMedium)
+        OutlinedButton(
+            onClick = { change((value - step).coerceAtLeast(min)) },
+            modifier = Modifier.width(52.dp),
+            contentPadding = PaddingValues(0.dp),
+            enabled = value > min,
+        ) { Text("−") }
+        Box(Modifier.width(84.dp), contentAlignment = Alignment.Center) {
+            Text("${String.format(java.util.Locale.US, "%.2f", value)} mm", style = MaterialTheme.typography.titleMedium)
         }
+        OutlinedButton(
+            onClick = { change((value + step).coerceAtMost(max)) },
+            modifier = Modifier.width(52.dp),
+            contentPadding = PaddingValues(0.dp),
+            enabled = value < max,
+        ) { Text("+") }
     }
 }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -268,15 +268,29 @@ internal fun SpacingControl(
     max: Float,
     change: (Float) -> Unit,
 ) {
-    Row(
-        Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.titleMedium)
-        OutlinedButton(onClick = { change((value - step).coerceAtLeast(min)) }, enabled = value > min) { Text("−") }
-        Text("${String.format(java.util.Locale.US, "%.2f", value)} mm", style = MaterialTheme.typography.titleMedium)
-        OutlinedButton(onClick = { change((value + step).coerceAtMost(max)) }, enabled = value < max) { Text("+") }
+    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(label, style = MaterialTheme.typography.titleMedium)
+        Row(
+            Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End,
+        ) {
+            OutlinedButton(
+                onClick = { change((value - step).coerceAtLeast(min)) },
+                modifier = Modifier.width(56.dp),
+                contentPadding = PaddingValues(0.dp),
+                enabled = value > min,
+            ) { Text("−") }
+            Box(Modifier.width(96.dp), contentAlignment = Alignment.Center) {
+                Text("${String.format(java.util.Locale.US, "%.2f", value)} mm", style = MaterialTheme.typography.titleMedium)
+            }
+            OutlinedButton(
+                onClick = { change((value + step).coerceAtMost(max)) },
+                modifier = Modifier.width(56.dp),
+                contentPadding = PaddingValues(0.dp),
+                enabled = value < max,
+            ) { Text("+") }
+        }
     }
 }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
@@ -66,7 +66,6 @@ import com.jaafar.remoteconfig.R
         Page("Fine-tune your font", back) { Text("Choose a handwriting font first.") }
         return
     }
-    val context = LocalContext.current
     val requiredCharacters = vm.activeCharacterOrder.toSet()
     val drawnCodePoints = project.drawings.map { it.codePoint }.toSet()
     val drawn = drawnCodePoints.intersect(requiredCharacters).size
@@ -123,19 +122,6 @@ import com.jaafar.remoteconfig.R
             }
             OutlinedButton(onClick = startDrawing, modifier = Modifier.fillMaxWidth()) {
                 Text("Continue drawing")
-            }
-            vm.generatedFont?.let { file ->
-                OutlinedButton(
-                    onClick = {
-                        val uri = FileProvider.getUriForFile(context, "${context.packageName}.files", file)
-                        context.startActivity(Intent.createChooser(Intent(Intent.ACTION_SEND).apply {
-                            type = "font/ttf"
-                            putExtra(Intent.EXTRA_STREAM, uri)
-                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                        }, "Share ${project.name}"))
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                ) { Text("Share font file") }
             }
         }
         if (vm.status.isNotBlank()) Text(vm.status, style = MaterialTheme.typography.bodySmall)


### PR DESCRIPTION
## Changes
- remove **Share font file** from Fine-tune your font
- keep each spacing control on one horizontal row
- use identical fixed-width minus, value, and plus columns
- align the minus and plus buttons vertically between letter spacing and word spacing

Layout:
- Letter spacing | − | value | +
- Word spacing | − | value | +