### PR TITLE
Reset Phrase Mode before continuing alphabet

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -172,6 +172,7 @@ fun FontCreatorApp(
                 onSave = { drawing ->
                     viewModel.saveDrawing(drawing)
                     if (viewModel.selectedCodePoint == null) {
+                        viewModel.disablePhraseMode()
                         viewModel.generate()
                         screen = Screen.FontReady
                     }
@@ -179,6 +180,7 @@ fun FontCreatorApp(
                 onSaveAndContinue = { drawing ->
                     viewModel.saveDrawingAndContinue(drawing)
                     if (viewModel.selectedCodePoint == null) {
+                        viewModel.disablePhraseMode()
                         viewModel.generate()
                         screen = Screen.FontReady
                     }
@@ -240,8 +242,10 @@ fun FontCreatorApp(
                     changePreviewText = { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() },
                     back = { screen = Screen.Letters },
                     startDrawing = {
+                        viewModel.disablePhraseMode()
                         screen = Screen.Letters
-                        viewModel.editLetters()
+                        val nextMissing = viewModel.activeCharacterOrder.firstOrNull { it !in viewModel.drawings }
+                        if (nextMissing != null) viewModel.edit(nextMissing) else viewModel.editLetters()
                     },
                     useOnImage = { fontName, text ->
                         preferredImageFontName = fontName

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
@@ -121,7 +121,7 @@ import com.jaafar.remoteconfig.R
                 Text("Use on an image")
             }
             OutlinedButton(onClick = startDrawing, modifier = Modifier.fillMaxWidth()) {
-                Text("Continue drawing")
+                Text("Continue full alphabet")
             }
         }
         if (vm.status.isNotBlank()) Text(vm.status, style = MaterialTheme.typography.bodySmall)


### PR DESCRIPTION
## Correct behavior
- **Save & Finish** explicitly ends Phrase Mode before opening Fine-tune
- the saved phrase remains available as preview and image text
- Fine-tune now labels the action **Continue full alphabet**
- the action defensively disables Phrase Mode
- it opens the complete selected-language letter bar at the next missing character
- if the alphabet is complete, it opens the standard full-letter editor