### PR TITLE
Guard phrase completion, font names, and sharing

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -125,22 +125,24 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         if (clean.isBlank()) { status = "Enter a name for the font."; return false }
         val requestedStorageKey = normalizedFontStorageKey(clean)
         if (requestedStorageKey.isBlank()) { status = "Use letters or numbers in the font name."; return false }
-        if (isDuplicateFontProjectName(projects.map { it.name }, clean)) {
+        if (hasFontName(clean)) {
             status = "A font with that name already exists."
             return false
         }
         projects.add(FontProject(clean)); openProject(projects.lastIndex); persist(); return true
     }
 
-    fun hasProjectName(name: String): Boolean {
+    fun hasFontName(name: String, excludingProjectIndex: Int? = null): Boolean {
         val clean = name.trim()
         if (clean.isBlank()) return false
         val requestedStorageKey = normalizedFontStorageKey(clean)
         if (requestedStorageKey.isBlank()) return false
-        return projects.any { project ->
-            project.name.equals(clean, ignoreCase = true) || normalizedFontStorageKey(project.name) == requestedStorageKey
-        }
+        return projects.withIndex().any { (index, project) ->
+            index != excludingProjectIndex && fontNamesConflict(project.name, clean)
+        } || importedFonts.any { font -> fontNamesConflict(font.displayName, clean) }
     }
+
+    fun hasProjectName(name: String): Boolean = hasFontName(name)
 
     fun renameActiveProject(name: String): Boolean {
         val index = activeProjectIndex ?: return false
@@ -149,9 +151,7 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         if (clean.isBlank()) { status = "Enter a name for the font."; return false }
         val requestedStorageKey = normalizedFontStorageKey(clean)
         if (requestedStorageKey.isBlank()) { status = "Use letters or numbers in the font name."; return false }
-        if (projects.withIndex().any { (projectIndex, project) ->
-                projectIndex != index && (project.name.equals(clean, ignoreCase = true) || normalizedFontStorageKey(project.name) == requestedStorageKey)
-            }) {
+        if (hasFontName(clean, excludingProjectIndex = index)) {
             status = "A font with that name already exists."
             return false
         }
@@ -250,8 +250,7 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         val missingCharacters = phraseCharacters.filter { it !in drawings }
         if (missingCharacters.isEmpty()) {
             closeEditor()
-            phraseModeEnabled = false
-            prefs.edit().putBoolean(PREFS_PHRASE_MODE, false).apply()
+            clearPhraseModeState()
             status = "Phrase ready — all required characters are already available."
         } else {
             startQueue(missingCharacters, "Phrase ready — all required characters are already available.")
@@ -267,6 +266,18 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
             pagingQueue = emptyList()
             pagingHistory = emptyList()
         }
+    }
+
+    private fun clearPhraseModeState() {
+        phraseModeEnabled = false
+        lastPhrase = ""
+        pagingQueue = emptyList()
+        pagingHistory = emptyList()
+        pagingTotal = 0
+        prefs.edit()
+            .remove(PREFS_PHRASE_MODE)
+            .remove(PREFS_LAST_PHRASE)
+            .apply()
     }
 
     private fun startQueue(queue: List<Int>, emptyMessage: String) {
@@ -321,8 +332,7 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         val phraseFinished = selectedCodePoint == null && phraseModeEnabled
         if (selectedCodePoint == null) isPagingMode = false
         if (phraseFinished) {
-            phraseModeEnabled = false
-            prefs.edit().putBoolean(PREFS_PHRASE_MODE, false).apply()
+            clearPhraseModeState()
         }
         syncActive(); persist(); status = if (phraseFinished) "Phrase ready." else "Glyph saved."
     }
@@ -360,6 +370,10 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
 
     fun importFont(contentResolver: ContentResolver, uri: Uri, displayName: String) {
         val cleanName = displayName.trim().ifEmpty { "Imported Font" }
+        if (hasFontName(cleanName)) {
+            importStatus = "A font with that name already exists."
+            return
+        }
         importStatus = "Importing…"
         executor.execute {
             runCatching {
@@ -593,6 +607,13 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
 
 internal fun applicablePhraseCodePoints(phrase: String, supported: Set<Int>): List<Int> =
     phrase.codePoints().toArray().toList().distinct().filter { it != 0x20 && it in supported }
+
+internal fun fontNamesConflict(first: String, second: String): Boolean {
+    val firstKey = normalizedFontStorageKey(first)
+    val secondKey = normalizedFontStorageKey(second)
+    return first.equals(second, ignoreCase = true) ||
+        (firstKey.isNotBlank() && firstKey == secondKey)
+}
 
 internal fun characterAfterSave(order: List<Int>, current: Int, drawn: Set<Int>, wasExisting: Boolean): Int? {
     if (order.isEmpty()) return null

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -64,7 +64,7 @@ import com.jaafar.remoteconfig.R
 ) = Page("Font workspace", back, actions = {
     val file = vm.generatedFont
     val project = vm.activeProject
-    if (file != null && project != null) ShareButton(file, project.name)
+    if (file != null && project != null && vm.isProjectComplete(project)) ShareButton(file, project.name)
 }) {
     val project = vm.activeProject
     val total = vm.activeCharacterOrder.size
@@ -142,10 +142,7 @@ import com.jaafar.remoteconfig.R
     if (showRenameDialog && project != null) {
         val cleanName = renameName.trim()
         val invalidName = cleanName.isNotEmpty() && normalizedFontStorageKey(cleanName).isBlank()
-        val duplicateName = vm.projects.withIndex().any { (index, candidate) ->
-            index != vm.activeProjectIndex && (candidate.name.equals(cleanName, ignoreCase = true) ||
-                normalizedFontStorageKey(candidate.name) == normalizedFontStorageKey(cleanName))
-        }
+        val duplicateName = vm.hasFontName(cleanName, excludingProjectIndex = vm.activeProjectIndex)
         val unchangedName = cleanName == project.name
         AlertDialog(
             onDismissRequest = { showRenameDialog = false },

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
@@ -120,7 +120,7 @@ internal fun CreateFontDialog(vm: FontCreatorViewModel, onCreated: () -> Unit, o
     var name by remember { mutableStateOf("") }
     val focusRequester = remember { FocusRequester() }
     val keyboard = LocalSoftwareKeyboardController.current
-    val duplicate = name.trim().isNotEmpty() && vm.hasProjectName(name)
+    val duplicate = name.trim().isNotEmpty() && vm.hasFontName(name)
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Name your font") },

--- a/app/src/test/java/com/jaafar/remoteconfig/fontcreator/FontNameUniquenessTest.kt
+++ b/app/src/test/java/com/jaafar/remoteconfig/fontcreator/FontNameUniquenessTest.kt
@@ -39,4 +39,11 @@ class FontNameUniquenessTest {
         assertFalse(isDuplicateFontProjectName(existingNames, "   "))
         assertFalse(isDuplicateFontProjectName(existingNames, "---___***"))
     }
+
+    @Test
+    fun `created and imported names conflict across normalized variants`() {
+        assertTrue(fontNamesConflict("Test Font", "test-font"))
+        assertTrue(fontNamesConflict("test_font", "TEST FONT"))
+        assertFalse(fontNamesConflict("Test Font", "Another Font"))
+    }
 }


### PR DESCRIPTION
## Summary
- clear Phrase Mode state and the saved phrase after Save & Finish
- enforce normalized, case-insensitive name uniqueness across created and imported fonts, including rename and import flows
- expose font-file sharing only after every selected-language character is complete
- add regression coverage for cross-source normalized name collisions

## Validation
- `git diff --check` passed locally
- Gradle tests will run in the repository's PR verification workflow (the repository has no Gradle wrapper and the local environment has no system Gradle)