### PR TITLE
Move font selection into image editor

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -84,7 +84,7 @@ private val ModernDarkColors = darkColorScheme(
     outlineVariant = Color(0xFF45464F),
 )
 
-internal enum class Screen { Home, Fonts, Signatures, Stamps, FontReady, Letters, Image, Signature, FillMark, Settings }
+internal enum class Screen { Home, Fonts, Signatures, Stamps, FontReady, Letters, Signature, FillMark, Settings }
 
 @Composable
 fun FontCreatorApp(
@@ -100,13 +100,18 @@ fun FontCreatorApp(
     var screen by remember { mutableStateOf(if (sharedUri != null) Screen.FillMark else Screen.Home) }
     var fillMarkUri by remember { mutableStateOf<Uri?>(sharedUri) }
     var imageUri by remember { mutableStateOf<Uri?>(null) }
-    var imageTypeface by remember { mutableStateOf<Typeface?>(null) }
     var preferredImageFontName by remember { mutableStateOf<String?>(null) }
     var initialImageText by remember { mutableStateOf("") }
-    var autoPickImage by remember { mutableStateOf(false) }
     var fontWorkspaceBack by remember { mutableStateOf(Screen.Home) }
     var pendingSignatureMark by remember { mutableStateOf<String?>(null) }
     var showCreateFontDialog by remember { mutableStateOf(false) }
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        imageUri = uri
+        if (uri == null) {
+            preferredImageFontName = null
+            initialImageText = ""
+        }
+    }
 
     // A running activity receives subsequent Share-sheet requests through onNewIntent.
     // Route every request straight to the editor, including a re-shared copy of the same file.
@@ -131,6 +136,14 @@ fun FontCreatorApp(
         val referenceTypeface = remember(viewModel.referenceFontKey, viewModel.projects.size, viewModel.importedFonts.size) {
             viewModel.referenceTypeface()
         }
+        val imageFontOptions = remember(viewModel.projects.toList(), viewModel.importedFonts.toList(), viewModel.generatedFont) {
+            listOf(
+                "Default" to Typeface.DEFAULT,
+                "Serif" to Typeface.SERIF,
+                "Sans-Serif" to Typeface.SANS_SERIF,
+                "Monospace" to Typeface.MONOSPACE,
+            ) + viewModel.allFontOptions()
+        }
         when {
             showTutorial -> FeatureTutorial(
                 onFinished = {
@@ -138,9 +151,14 @@ fun FontCreatorApp(
                     showTutorial = false
                 },
             )
-            imageUri != null && imageTypeface != null -> ImageTextEditorScreen(imageUri!!, imageTypeface!!, initialImageText) {
+            imageUri != null -> ImageTextEditorScreen(
+                imageUri = imageUri!!,
+                fontOptions = imageFontOptions,
+                initiallySelectedFont = preferredImageFontName,
+                initialText = initialImageText,
+            ) {
                 imageUri = null
-                imageTypeface = null
+                preferredImageFontName = null
                 initialImageText = ""
             }
             viewModel.selectedCodePoint != null -> GlyphEditorScreen(
@@ -202,8 +220,7 @@ fun FontCreatorApp(
                     useFontOnImage = { fontName ->
                         preferredImageFontName = fontName
                         initialImageText = ""
-                        autoPickImage = true
-                        screen = Screen.Image
+                        imagePicker.launch("image/*")
                     },
                     openFillMark = { screen = Screen.FillMark },
                     openFonts = { screen = Screen.Fonts },
@@ -250,8 +267,7 @@ fun FontCreatorApp(
                     useOnImage = { fontName, text ->
                         preferredImageFontName = fontName
                         initialImageText = text
-                        autoPickImage = true
-                        screen = Screen.Image
+                        imagePicker.launch("image/*")
                     },
                 )
                 Screen.Letters -> LettersScreen(
@@ -264,17 +280,9 @@ fun FontCreatorApp(
                     useOnImage = { fontName ->
                         preferredImageFontName = fontName
                         initialImageText = previewText
-                        autoPickImage = true
-                        screen = Screen.Image
+                        imagePicker.launch("image/*")
                     },
                 )
-                Screen.Image -> ImageScreen(
-                    vm = viewModel,
-                    back = { preferredImageFontName = null; initialImageText = ""; autoPickImage = false; screen = Screen.Home },
-                    initiallySelectedFont = preferredImageFontName,
-                    autoPickImage = autoPickImage,
-                    onAutoPickConsumed = { autoPickImage = false },
-                ) { tf, uri -> imageTypeface = tf; imageUri = uri; preferredImageFontName = null }
                 Screen.Signature -> SignatureScreen(
                     vm = viewModel,
                     initialMarkName = pendingSignatureMark,
@@ -385,66 +393,6 @@ private fun appTypography(fontFamily: FontFamily?): Typography {
         bodyLarge = base.bodyLarge.withSelectedFont(), bodyMedium = base.bodyMedium.withSelectedFont(), bodySmall = base.bodySmall.withSelectedFont(),
         labelLarge = base.labelLarge.withSelectedFont(), labelMedium = base.labelMedium.withSelectedFont(), labelSmall = base.labelSmall.withSelectedFont(),
     )
-}
-
-private const val PREF_KEY_LAST_IMAGE_FONT = "last_font"
-
-@Composable private fun ImageScreen(
-    vm: FontCreatorViewModel,
-    back: () -> Unit,
-    initiallySelectedFont: String? = null,
-    autoPickImage: Boolean = false,
-    onAutoPickConsumed: () -> Unit = {},
-    selected: (Typeface, Uri) -> Unit,
-) {
-    val context = LocalContext.current
-    val preferences = remember { context.getSharedPreferences("image_editor", 0) }
-    val allFonts = remember(vm.projects.toList(), vm.importedFonts.toList(), vm.generatedFont) { vm.allFontOptions() }
-    val systemFonts = listOf("Default" to Typeface.DEFAULT, "Serif" to Typeface.SERIF, "Sans-Serif" to Typeface.SANS_SERIF, "Monospace" to Typeface.MONOSPACE)
-    val allAvailable = systemFonts + allFonts
-    val lastSavedFont = remember { preferences.getString(PREF_KEY_LAST_IMAGE_FONT, null) }
-    var selectedFontLabel by remember(allAvailable, initiallySelectedFont) {
-        val resolved = when {
-            initiallySelectedFont != null && allAvailable.any { it.first == initiallySelectedFont } -> initiallySelectedFont
-            lastSavedFont != null && allAvailable.any { it.first == lastSavedFont } -> lastSavedFont
-            else -> allAvailable.firstOrNull()?.first ?: "Default"
-        }
-        mutableStateOf(resolved)
-    }
-    var expanded by remember { mutableStateOf(false) }
-    val picker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        if (uri != null) {
-            val tf = allAvailable.firstOrNull { it.first == selectedFontLabel }?.second ?: Typeface.DEFAULT
-            preferences.edit().putString(PREF_KEY_LAST_IMAGE_FONT, selectedFontLabel).apply()
-            selected(tf, uri)
-        }
-    }
-    LaunchedEffect(autoPickImage) {
-        if (autoPickImage) {
-            picker.launch("image/*")
-            onAutoPickConsumed()
-        }
-    }
-    Page("Edit an image", back, scrollable = true) {
-        Text("Choose a font and add styled text, a signature, or a stamp to an image.")
-        Box {
-            OutlinedButton({ expanded = true }, Modifier.fillMaxWidth()) { Text("Font: $selectedFontLabel") }
-            DropdownMenu(expanded, { expanded = false }) {
-                allAvailable.forEach { (label, _) ->
-                    DropdownMenuItem(
-                        text = { Text(label) },
-                        onClick = {
-                            selectedFontLabel = label
-                            expanded = false
-                            preferences.edit().putString(PREF_KEY_LAST_IMAGE_FONT, label).apply()
-                        },
-                        trailingIcon = { if (label == selectedFontLabel) Text("✓") },
-                    )
-                }
-            }
-        }
-        Button({ picker.launch("image/*") }, Modifier.fillMaxWidth()) { Text("Choose image") }
-    }
 }
 
 @Composable private fun SettingsScreen(

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -18,11 +18,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
@@ -54,6 +59,7 @@ import java.io.FileOutputStream
 import kotlin.math.roundToInt
 
 private data class TextColorOption(val name: String, val value: Int, val composeColor: Color)
+private const val PREF_KEY_LAST_IMAGE_FONT = "last_font"
 
 private val TEXT_COLORS = listOf(
     TextColorOption("White", android.graphics.Color.WHITE, Color.White),
@@ -66,14 +72,33 @@ private val TEXT_COLORS = listOf(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ImageTextEditorScreen(imageUri: Uri, typeface: Typeface, initialText: String = "", onBack: () -> Unit) {
+fun ImageTextEditorScreen(
+    imageUri: Uri,
+    fontOptions: List<Pair<String, Typeface>>,
+    initiallySelectedFont: String? = null,
+    initialText: String = "",
+    onBack: () -> Unit,
+) {
     val context = LocalContext.current
+    val preferences = remember { context.getSharedPreferences("image_editor", 0) }
     val bitmap = remember(imageUri) { loadBitmap(context.contentResolver, imageUri) }
+    val lastSavedFont = remember { preferences.getString(PREF_KEY_LAST_IMAGE_FONT, null) }
+    var selectedFontLabel by remember(fontOptions, initiallySelectedFont) {
+        val resolved = when {
+            initiallySelectedFont != null && fontOptions.any { it.first == initiallySelectedFont } -> initiallySelectedFont
+            lastSavedFont != null && fontOptions.any { it.first == lastSavedFont } -> lastSavedFont
+            else -> fontOptions.firstOrNull()?.first ?: "Default"
+        }
+        mutableStateOf(resolved)
+    }
+    val typeface = fontOptions.firstOrNull { it.first == selectedFontLabel }?.second ?: Typeface.DEFAULT
     var text by remember(imageUri, initialText) { mutableStateOf(initialText) }
     var sizePercent by remember { mutableFloatStateOf(10f) }
     var textColor by remember { mutableStateOf(TEXT_COLORS.first()) }
     var textPosition by remember { mutableStateOf(Offset(.5f, .85f)) }
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+    var showFontPicker by remember { mutableStateOf(false) }
+    var fontQuery by remember { mutableStateOf("") }
 
     BackHandler(onBack = onBack)
     Scaffold(topBar = { AppTopBar("Write on image", onBack) }) { padding ->
@@ -113,6 +138,9 @@ fun ImageTextEditorScreen(imageUri: Uri, typeface: Typeface, initialText: String
                     }
                 }
                 Text("Drag on the image to move the text")
+                OutlinedButton(onClick = { showFontPicker = true }, modifier = Modifier.fillMaxWidth()) {
+                    Text("Font: $selectedFontLabel", fontFamily = androidx.compose.ui.text.font.FontFamily(typeface))
+                }
                 OutlinedTextField(
                     value = text,
                     onValueChange = { text = it },
@@ -144,6 +172,42 @@ fun ImageTextEditorScreen(imageUri: Uri, typeface: Typeface, initialText: String
                         enabled = text.isNotBlank(), modifier = Modifier.fillMaxWidth(),
                         onClick = { shareImage(context, renderImage(bitmap, text, typeface, sizePercent, textColor.value, textPosition)) },
                     ) { Text("Share image") }
+                }
+            }
+        }
+    }
+    if (showFontPicker) {
+        ModalBottomSheet(onDismissRequest = { showFontPicker = false }) {
+            Column(
+                Modifier.fillMaxWidth().padding(horizontal = 16.dp).padding(bottom = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text("Choose font", style = MaterialTheme.typography.titleLarge)
+                OutlinedTextField(
+                    value = fontQuery,
+                    onValueChange = { fontQuery = it },
+                    label = { Text("Search fonts") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                val visibleFonts = fontOptions.filter { (label, _) -> label.contains(fontQuery, ignoreCase = true) }
+                LazyColumn(Modifier.fillMaxWidth().heightIn(max = 360.dp)) {
+                    items(visibleFonts, key = { it.first }) { (label, optionTypeface) ->
+                        OutlinedButton(
+                            onClick = {
+                                selectedFontLabel = label
+                                preferences.edit().putString(PREF_KEY_LAST_IMAGE_FONT, label).apply()
+                                showFontPicker = false
+                                fontQuery = ""
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(
+                                if (label == selectedFontLabel) "✓  $label" else label,
+                                fontFamily = androidx.compose.ui.text.font.FontFamily(optionTypeface),
+                            )
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- remove the separate Edit an image setup screen
- launch the system image picker directly from each Use on image action
- add a searchable font picker bottom sheet inside Write on image
- preview each font in its own typeface and apply changes live
- preserve the last selected font and the originating screen when leaving the editor

## Verification
- `git diff --check` passes
- local Gradle tests could not run because this repository does not include a Gradle wrapper and Gradle is not installed in the workspace
- GitHub Actions is expected to run the Android build on this PR