### PR TITLE
Edit image text directly on the canvas

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -138,8 +138,8 @@ fun ImageTextEditorScreen(
             .apply()
     }
 
-    LaunchedEffect(isEditingText) {
-        if (isEditingText) {
+    LaunchedEffect(isEditingText, canvasSize) {
+        if (isEditingText && canvasSize.width > 0 && canvasSize.height > 0) {
             textFocusRequester.requestFocus()
             keyboard?.show()
         }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -119,7 +119,7 @@ fun ImageTextEditorScreen(
     var textPosition by remember { mutableStateOf(Offset(.5f, .85f)) }
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
     var activePanel by remember { mutableStateOf<EditorPanel?>(null) }
-    var isEditingText by remember { mutableStateOf(initialText.isBlank()) }
+    var isEditingText by remember { mutableStateOf(false) }
     var fontQuery by remember { mutableStateOf("") }
     var showAllFonts by remember { mutableStateOf(false) }
     var fontFilter by remember { mutableStateOf(FontFilter.All) }
@@ -140,8 +140,10 @@ fun ImageTextEditorScreen(
 
     LaunchedEffect(isEditingText, canvasSize) {
         if (isEditingText && canvasSize.width > 0 && canvasSize.height > 0) {
-            textFocusRequester.requestFocus()
-            keyboard?.show()
+            runCatching {
+                textFocusRequester.requestFocus()
+                keyboard?.show()
+            }
         }
     }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.Canvas as ComposeCanvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -25,6 +27,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -37,6 +40,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -44,16 +48,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -88,6 +97,9 @@ fun ImageTextEditorScreen(
     onBack: () -> Unit,
 ) {
     val context = LocalContext.current
+    val density = LocalDensity.current
+    val keyboard = LocalSoftwareKeyboardController.current
+    val textFocusRequester = remember { FocusRequester() }
     val preferences = remember { context.getSharedPreferences("image_editor", 0) }
     val bitmap = remember(imageUri) { loadBitmap(context.contentResolver, imageUri) }
     val lastSavedFont = remember { preferences.getString(PREF_KEY_LAST_IMAGE_FONT, null) }
@@ -106,6 +118,7 @@ fun ImageTextEditorScreen(
     var textPosition by remember { mutableStateOf(Offset(.5f, .85f)) }
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
     var activePanel by remember { mutableStateOf<EditorPanel?>(null) }
+    var isEditingText by remember { mutableStateOf(initialText.isBlank()) }
     var fontQuery by remember { mutableStateOf("") }
     var showAllFonts by remember { mutableStateOf(false) }
     var fontFilter by remember { mutableStateOf(FontFilter.All) }
@@ -124,18 +137,35 @@ fun ImageTextEditorScreen(
             .apply()
     }
 
-    BackHandler(onBack = onBack)
+    LaunchedEffect(isEditingText) {
+        if (isEditingText) {
+            textFocusRequester.requestFocus()
+            keyboard?.show()
+        }
+    }
+
+    BackHandler {
+        when {
+            activePanel != null -> activePanel = null
+            isEditingText -> { isEditingText = false; keyboard?.hide() }
+            else -> onBack()
+        }
+    }
     Scaffold(
         topBar = {
             AppTopBar("Write on image", onBack) {
-                TextButton(
-                    enabled = bitmap != null && text.isNotBlank(),
-                    onClick = {
-                        bitmap?.let { source ->
-                            shareImage(context, renderImage(source, text, typeface, sizePercent, textColor.value, textPosition))
-                        }
-                    },
-                ) { Text("Share") }
+                if (isEditingText) {
+                    TextButton(onClick = { isEditingText = false; keyboard?.hide() }) { Text("Done") }
+                } else {
+                    TextButton(
+                        enabled = bitmap != null && text.isNotBlank(),
+                        onClick = {
+                            bitmap?.let { source ->
+                                shareImage(context, renderImage(source, text, typeface, sizePercent, textColor.value, textPosition))
+                            }
+                        },
+                    ) { Text("Share") }
+                }
             }
         },
     ) { padding ->
@@ -143,17 +173,17 @@ fun ImageTextEditorScreen(
             if (bitmap == null) {
                 Text("This image could not be opened.", color = MaterialTheme.colorScheme.error)
             } else {
-                ComposeCanvas(
+                Box(
                     Modifier.fillMaxWidth().weight(1f).background(Color.Black)
-                        .onSizeChanged { canvasSize = it }
-                        // Position changes on every pointer event. Keeping it out of the keys prevents
-                        // Compose from cancelling and recreating this detector mid-gesture.
-                        .pointerInput(bitmap, canvasSize, text, typeface, sizePercent) {
-                            var canDragText = false
-                            detectDragGestures(
-                                onDragStart = { pointer ->
-                                    canDragText = isPointNearOverlayText(
-                                        pointer = pointer,
+                        .onSizeChanged { canvasSize = it },
+                ) {
+                    ComposeCanvas(
+                        Modifier.fillMaxSize()
+                            .pointerInput(bitmap, canvasSize, text, typeface) {
+                                detectTransformGestures { centroid, pan, zoom, _ ->
+                                    val imageSize = displayedImageSize(canvasSize, bitmap.width, bitmap.height)
+                                    val touchesText = isPointNearOverlayText(
+                                        pointer = centroid,
                                         canvasSize = canvasSize,
                                         imageWidth = bitmap.width,
                                         imageHeight = bitmap.height,
@@ -163,44 +193,80 @@ fun ImageTextEditorScreen(
                                         textPosition = textPosition,
                                         touchPadding = 24.dp.toPx(),
                                     )
-                                },
-                                onDragEnd = { canDragText = false },
-                                onDragCancel = { canDragText = false },
-                            ) { change, dragAmount ->
-                                if (canDragText) {
-                                    change.consume()
-                                    val imageSize = displayedImageSize(canvasSize, bitmap.width, bitmap.height)
-                                    if (imageSize.width > 0 && imageSize.height > 0) {
+                                    if (!isEditingText && touchesText && imageSize.width > 0 && imageSize.height > 0) {
                                         textPosition = Offset(
-                                            (textPosition.x + dragAmount.x / imageSize.width).coerceIn(0f, 1f),
-                                            (textPosition.y + dragAmount.y / imageSize.height).coerceIn(0f, 1f),
+                                            (textPosition.x + pan.x / imageSize.width).coerceIn(0f, 1f),
+                                            (textPosition.y + pan.y / imageSize.height).coerceIn(0f, 1f),
                                         )
+                                        sizePercent = (sizePercent * zoom).coerceIn(4f, 24f)
                                     }
                                 }
                             }
-                        },
-                ) {
-                    val scale = minOf(size.width / bitmap.width, size.height / bitmap.height)
-                    val width = (bitmap.width * scale).roundToInt()
-                    val height = (bitmap.height * scale).roundToInt()
-                    val left = ((size.width - width) / 2f).roundToInt()
-                    val top = ((size.height - height) / 2f).roundToInt()
-                    drawImage(bitmap.asImageBitmap(), dstOffset = IntOffset(left, top), dstSize = IntSize(width, height))
-                    drawIntoCanvas { canvas ->
-                        val paint = overlayPaint(typeface, height * sizePercent / 100f, textColor.value)
-                        drawOverlayText(
-                            canvas.nativeCanvas, text,
-                            left + width * textPosition.x, top + height * textPosition.y,
-                            width * .9f, paint,
+                            .pointerInput(bitmap, canvasSize, text, typeface) {
+                                detectTapGestures { pointer ->
+                                    val touchesText = isPointNearOverlayText(
+                                            pointer, canvasSize, bitmap.width, bitmap.height, text,
+                                            typeface, sizePercent, textPosition, 24.dp.toPx(),
+                                        )
+                                    if (touchesText) {
+                                        isEditingText = true
+                                    } else if (isEditingText) {
+                                        isEditingText = false
+                                        keyboard?.hide()
+                                    }
+                                }
+                            },
+                    ) {
+                        val scale = minOf(size.width / bitmap.width, size.height / bitmap.height)
+                        val width = (bitmap.width * scale).roundToInt()
+                        val height = (bitmap.height * scale).roundToInt()
+                        val left = ((size.width - width) / 2f).roundToInt()
+                        val top = ((size.height - height) / 2f).roundToInt()
+                        drawImage(bitmap.asImageBitmap(), dstOffset = IntOffset(left, top), dstSize = IntSize(width, height))
+                        if (!isEditingText) {
+                            drawIntoCanvas { canvas ->
+                                val paint = overlayPaint(typeface, height * sizePercent / 100f, textColor.value)
+                                drawOverlayText(
+                                    canvas.nativeCanvas, text,
+                                    left + width * textPosition.x, top + height * textPosition.y,
+                                    width * .9f, paint,
+                                )
+                            }
+                        }
+                    }
+                    if (isEditingText && canvasSize.width > 0 && canvasSize.height > 0) {
+                        val imageSize = displayedImageSize(canvasSize, bitmap.width, bitmap.height)
+                        val imageLeft = (canvasSize.width - imageSize.width) / 2f
+                        val imageTop = (canvasSize.height - imageSize.height) / 2f
+                        val editorWidthPx = imageSize.width * .9f
+                        val textSizePx = imageSize.height * sizePercent / 100f
+                        val centerX = imageLeft + imageSize.width * textPosition.x
+                        val baselineY = imageTop + imageSize.height * textPosition.y
+                        BasicTextField(
+                            value = text,
+                            onValueChange = { text = it },
+                            modifier = Modifier
+                                .offset { IntOffset((centerX - editorWidthPx / 2f).roundToInt(), (baselineY - textSizePx).roundToInt()) }
+                                .width(with(density) { editorWidthPx.toDp() })
+                                .border(1.dp, MaterialTheme.colorScheme.primary)
+                                .background(MaterialTheme.colorScheme.surface.copy(alpha = .35f))
+                                .padding(6.dp)
+                                .focusRequester(textFocusRequester),
+                            textStyle = MaterialTheme.typography.bodyLarge.copy(
+                                color = textColor.composeColor,
+                                fontFamily = androidx.compose.ui.text.font.FontFamily(typeface),
+                                fontSize = with(density) { textSizePx.toSp() },
+                                textAlign = TextAlign.Center,
+                            ),
                         )
                     }
                 }
                 Text("Drag the text to reposition it", style = MaterialTheme.typography.bodySmall)
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    EditorToolButton("Text", EditorPanel.Text) { activePanel = it }
-                    EditorToolButton("Font", EditorPanel.Font) { activePanel = it }
-                    EditorToolButton("Size", EditorPanel.Size) { activePanel = it }
-                    EditorToolButton("Color", EditorPanel.Color) { activePanel = it }
+                    EditorToolButton("Text", EditorPanel.Text) { activePanel = null; isEditingText = true }
+                    EditorToolButton("Font", EditorPanel.Font) { isEditingText = false; keyboard?.hide(); activePanel = it }
+                    EditorToolButton("Size", EditorPanel.Size) { isEditingText = false; keyboard?.hide(); activePanel = it }
+                    EditorToolButton("Color", EditorPanel.Color) { isEditingText = false; keyboard?.hide(); activePanel = it }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace the separate text-entry sheet with an editable text field positioned directly over the image
- focus the canvas text and open the keyboard when adding new text
- use Done or tap outside to finish editing, and tap the rendered text to edit it again
- keep Share in the top bar when editing is complete
- support direct dragging and pinch-to-resize on the rendered text layer
- preserve font, color, size, wrapping, recent-font selection, and export behavior
- make Back dismiss the active panel or text edit mode before leaving the editor

## Verification
- `git diff --check` passes
- Android verification will run in GitHub Actions