### PR TITLE
Rename app to Font Maker

### DIFF
--- a/JOURNEY_TEST_PLAN.md
+++ b/JOURNEY_TEST_PLAN.md
@@ -7,16 +7,16 @@ This checklist is for every release APK. It separates checks verified by reading
 | ID | Journey | Result | Notes |
 | --- | --- | --- | --- |
 | FONT-03 | Complete a selected character set | Fixed in this PR | Completion previously counted all saved drawings, including optional characters. It now checks every required character. |
-| DOC-01 | Add a text mark | Pass — code checked | The flow is Text → tap location → type → Add text. |
-| DOC-02 | Select, edit, move, and delete a mark | Pass — code checked | Selected marks expose Edit and Delete; dragging updates position. |
-| NAV-01 | Home navigation | Pass — code checked | Home routes to documents, images, fonts, library, restyle, and settings. |
+| DOC-01 | Add a text mark | Pass â€” code checked | The flow is Text â†’ tap location â†’ type â†’ Add text. |
+| DOC-02 | Select, edit, move, and delete a mark | Pass â€” code checked | Selected marks expose Edit and Delete; dragging updates position. |
+| NAV-01 | Home navigation | Pass â€” code checked | Home routes to documents, images, fonts, library, restyle, and settings. |
 | DEVICE-01 to DEVICE-10 | Files, sharing, rendering, and updates | Manual device test required | These depend on Android storage, installed apps, and real PDF/image files. |
 
 ## 1. Home and navigation
 
 | ID | Steps | Expected result | Status |
 | --- | --- | --- | --- |
-| NAV-01 | Open the app. | Home title is **Font Creator**. | Code checked |
+| NAV-01 | Open the app. | Home title is **Font Maker**. | Code checked |
 | NAV-02 | Open each home card, then use Back. | Page opens and Back returns to Home without losing the app state. | Manual |
 | NAV-03 | Open Settings, switch dark mode, close and reopen the app. | Theme choice remains selected. | Manual |
 | NAV-04 | Open My Library with no saved assets. | Clear empty-state information is shown; no crash. | Code checked |
@@ -25,7 +25,7 @@ This checklist is for every release APK. It separates checks verified by reading
 
 | ID | Steps | Expected result | Status |
 | --- | --- | --- | --- |
-| FONT-01 | Fonts → Create a handwriting font → name it → choose letters. | New project opens the drawing journey. | Manual |
+| FONT-01 | Fonts â†’ Create a handwriting font â†’ name it â†’ choose letters. | New project opens the drawing journey. | Manual |
 | FONT-02 | Draw a character, Save & Next, then return to Fonts. | Progress increases by one required character. | Code checked |
 | FONT-03 | Draw required letters plus extra phrase letters. | The font is complete only when every selected character has been drawn. | Fixed / code checked |
 | FONT-04 | Finish all selected letters. | Completion screen says the font is ready; it does not offer duplicate continuation actions. | Manual |
@@ -55,9 +55,9 @@ This checklist is for every release APK. It separates checks verified by reading
 
 | ID | Steps | Expected result | Status |
 | --- | --- | --- | --- |
-| DOC-01 | Choose a PDF or image → Text → tap a location → type text → Add text. | Text appears at the selected location. | Code checked |
+| DOC-01 | Choose a PDF or image â†’ Text â†’ tap a location â†’ type text â†’ Add text. | Text appears at the selected location. | Code checked |
 | DOC-02 | Select added text. Edit its content, drag it, then Delete it. | Each change is visible immediately; Delete removes the mark. | Code checked |
-| DOC-03 | Choose Quick → Approved/Paid/Received/Confidential → tap a location. | Preset is placed at that location. | Code checked |
+| DOC-03 | Choose Quick â†’ Approved/Paid/Received/Confidential â†’ tap a location. | Preset is placed at that location. | Code checked |
 | DOC-04 | Add Date and Check marks. | Each mark uses the selected style and color. | Manual |
 | DOC-05 | Add a signature or stamp. | A visible saved asset is placed, can be moved, edited, and deleted. | Manual |
 | DOC-06 | Use a multi-page PDF. Add a mark to one page, then choose All pages. | Mark appears only on selected page first, then on every page after All pages. | Manual |
@@ -99,3 +99,4 @@ This checklist is for every release APK. It separates checks verified by reading
 2. Run every Manual item on a physical phone using a PDF, an image, a valid TTF/OTF, and one invalid file.
 3. Record the test ID and attach a screenshot for any failure.
 4. Do not publish a release until all required manual tests pass.
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Font Creator
+# Font Maker
 
 A Kotlin + Jetpack Compose Android app for creating and importing fonts, writing on images, and filling, signing, or stamping documents.
 
@@ -6,7 +6,7 @@ A Kotlin + Jetpack Compose Android app for creating and importing fonts, writing
 
 Every pull request runs tests and creates a release Android App Bundle (AAB) artifact.
 
-When the required repository secrets are configured, the same workflow also uploads the AAB to the **Google Play Internal testing** track. Install it through the Play Store testing link to test an update before merging the pull request—no APK download or uninstall is needed.
+When the required repository secrets are configured, the same workflow also uploads the AAB to the **Google Play Internal testing** track. Install it through the Play Store testing link to test an update before merging the pull requestâ€”no APK download or uninstall is needed.
 
 The workflow uses GitHub's run number as Android's version code, so each PR test build is a valid upgrade.
 
@@ -16,10 +16,11 @@ The workflow uses GitHub's run number as Android's version code, so each PR test
 - `ANDROID_KEYSTORE_PASSWORD`
 - `ANDROID_KEY_ALIAS`
 - `ANDROID_KEY_PASSWORD`
-- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` — the complete JSON of a Google Cloud service account that has Google Play Console release access.
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` â€” the complete JSON of a Google Cloud service account that has Google Play Console release access.
 
 Configure the service account in Play Console under **Users and permissions**, then grant it release access for this app. The workflow only targets the **internal** track; it never publishes to closed testing or production.
 
 ## Important
 
 Telegram should control content/configuration through the backend. It must never install arbitrary APKs or execute code received from Telegram. New app code should continue through pull requests, testing, merge, and a signed release pipeline.
+

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -381,7 +381,7 @@ fun FontCreatorApp(
                         Text("Aa", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
                     }
                 }
-                Text(if (title == "Studio") "Font Creator" else title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Text(if (title == "Studio") "Font Maker" else title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
             }
         },
         navigationIcon = {
@@ -469,7 +469,7 @@ private fun appTypography(fontFamily: FontFamily?): Typography {
                 DropdownMenuItem(
                     text = { Text(key) },
                     onClick = { vm.setReferenceFont(key); refExpanded = false },
-                    trailingIcon = { if (key == vm.referenceFontKey) Text("✓") },
+                    trailingIcon = { if (key == vm.referenceFontKey) Text("âœ“") },
                 )
             }
         }
@@ -501,3 +501,4 @@ private fun openPlayStoreListing(context: android.content.Context) {
             context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=$packageName")))
         }
 }
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,1 +1,2 @@
-<resources><string name="app_name">Font Creator</string></resources>
+<resources><string name="app_name">Font Maker</string></resources>
+


### PR DESCRIPTION
## Summary
- changes the Android launcher name from **Font Creator** to **Font Maker**
- updates the dashboard header to **Font Maker**
- updates repository documentation and the journey test plan
- preserves the existing application ID, signing configuration, Play Console app, and opt-in testing track

## Release notes
- Renamed the app to **Font Maker** for clearer, more consistent branding.