### PR TITLE
Tune fonts: proportional letter widths, recency defaults, icon toolbar (matches iOS)

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/DashboardScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/DashboardScreen.kt
@@ -40,9 +40,16 @@ internal fun DashboardScreen(
         IconButton(onClick = openSettings) { Icon(Icons.Filled.Settings, contentDescription = "Settings") }
     },
 ) {
-    val unfinishedIndex = vm.projects.indexOfFirst { !vm.isProjectComplete(it) }.takeIf { it >= 0 }
+    // Picked by lastModifiedAt, matching the iOS app's equivalent defaults -- createProject
+    // appends new projects at the end of the list, so indexOfFirst/lastOrNull only ever
+    // reflected creation order and went stale the moment an *older* project was edited
+    // instead of a brand new one being added.
+    val unfinishedIndex = vm.projects.withIndex()
+        .filter { (_, project) -> !vm.isProjectComplete(project) }
+        .maxByOrNull { (_, project) -> project.lastModifiedAt }
+        ?.index
     val preferredFont = vm.activeProject?.name
-        ?: vm.projects.lastOrNull()?.name
+        ?: vm.projects.maxByOrNull { it.lastModifiedAt }?.name
         ?: vm.importedFonts.firstOrNull()?.displayName
     val hasAnyFont = vm.projects.isNotEmpty() || vm.importedFonts.isNotEmpty()
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -158,7 +158,7 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         if (current.name == clean) return true
 
         syncActive()
-        val renamed = projects[index].copy(name = clean)
+        val renamed = projects[index].copy(name = clean, lastModifiedAt = System.currentTimeMillis())
         projects[index] = renamed
         persist()
         if (referenceFontKey == current.name) setReferenceFont(clean)
@@ -597,8 +597,18 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
 
     private fun loadTypeface(file: File) = if (Build.VERSION.SDK_INT >= 26) Typeface.Builder(file).build() else Typeface.createFromFile(file)
     private fun generatedFile(name: String) = File(getApplication<Application>().filesDir, "font-${normalizedFontStorageKey(name)}.ttf")
-    private fun updateActive(transform: (FontProject) -> FontProject) { val index = activeProjectIndex ?: return; projects[index] = transform(projects[index]); persist() }
-    private fun syncActive() { val index = activeProjectIndex ?: return; projects[index] = projects[index].copy(drawings = drawings.values.toList()) }
+    // Both helpers stamp lastModifiedAt centrally (matching the iOS app's updateFont()) so
+    // every edit path -- rename, spacing, language selection, saving a drawn letter -- keeps
+    // it current without each call site having to remember to.
+    private fun updateActive(transform: (FontProject) -> FontProject) {
+        val index = activeProjectIndex ?: return
+        projects[index] = transform(projects[index]).copy(lastModifiedAt = System.currentTimeMillis())
+        persist()
+    }
+    private fun syncActive() {
+        val index = activeProjectIndex ?: return
+        projects[index] = projects[index].copy(drawings = drawings.values.toList(), lastModifiedAt = System.currentTimeMillis())
+    }
     private fun persist() { val snapshot = projects.toList(); executor.execute { repository.save(snapshot) } }
     private fun persistSignatures() { val snapshot = signatures.toList(); executor.execute { signatureRepository.save(snapshot) } }
     private fun persistImportedFonts() { val snapshot = importedFonts.toList(); executor.execute { importedFontRepository.save(snapshot) } }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontModels.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontModels.kt
@@ -38,6 +38,12 @@ data class FontProject(
     val letterSpacingMm: Float = 0f,
     val wordSpacingMm: Float = 3f,
     val selectedLanguages: Set<LanguageScript> = setOf(LanguageScript.BASIC_LATIN),
+    /** When this project was created or last edited -- matches the iOS app's
+     *  `SavedAsset.lastModifiedAt`, used to find "the most recently created or modified
+     *  font" for defaults like the dashboard's "Continue" card and "Use font on image",
+     *  instead of relying on list order (which `createProject` only happens to preserve
+     *  as a recency proxy for *creation*, and never reflects a later edit). */
+    val lastModifiedAt: Long = System.currentTimeMillis(),
 )
 
 data class GlyphPoint(val x: Float, val y: Float, val onCurve: Boolean = true)

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/GlyphRepository.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/GlyphRepository.kt
@@ -31,6 +31,10 @@ class GlyphRepository(context: Context) {
                     letterSpacingMm = item.optDouble("letterSpacingMm", 0.0).toFloat(),
                     wordSpacingMm = item.optDouble("wordSpacingMm", 3.0).toFloat(),
                     selectedLanguages = selectedLanguages,
+                    // Projects saved before this field existed have no recorded edit time --
+                    // 0 sorts them before anything with a real timestamp, same as iOS's
+                    // decodeIfPresent-with-createdAt-fallback does for its equivalent field.
+                    lastModifiedAt = item.optLong("lastModifiedAt", 0L),
                 ))
             }
         }
@@ -48,6 +52,7 @@ class GlyphRepository(context: Context) {
                 put("letterSpacingMm", project.letterSpacingMm.toDouble())
                 put("wordSpacingMm", project.wordSpacingMm.toDouble())
                 put("selectedLanguages", JSONArray().apply { project.selectedLanguages.forEach { put(it.name) } })
+                put("lastModifiedAt", project.lastModifiedAt)
                 put("drawings", JSONArray().apply {
                     project.drawings.sortedBy { it.codePoint }.forEach { put(it.toJson()) }
                 })

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -30,9 +30,15 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FontDownload
+import androidx.compose.material.icons.filled.FormatSize
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -274,10 +280,10 @@ fun ImageTextEditorScreen(
                 }
                 Text("Drag the text to reposition it", style = MaterialTheme.typography.bodySmall)
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    EditorToolButton("Text", EditorPanel.Text) { activePanel = null; isEditingText = true }
-                    EditorToolButton("Font", EditorPanel.Font) { isEditingText = false; keyboard?.hide(); activePanel = it }
-                    EditorToolButton("Size", EditorPanel.Size) { isEditingText = false; keyboard?.hide(); activePanel = it }
-                    EditorToolButton("Color", EditorPanel.Color) { isEditingText = false; keyboard?.hide(); activePanel = it }
+                    EditorToolButton("Text", Icons.Filled.TextFields, EditorPanel.Text) { activePanel = null; isEditingText = true }
+                    EditorToolButton("Font", Icons.Filled.FontDownload, EditorPanel.Font) { isEditingText = false; keyboard?.hide(); activePanel = it }
+                    EditorToolButton("Size", Icons.Filled.FormatSize, EditorPanel.Size) { isEditingText = false; keyboard?.hide(); activePanel = it }
+                    EditorToolButton("Color", Icons.Filled.Palette, EditorPanel.Color) { isEditingText = false; keyboard?.hide(); activePanel = it }
                 }
             }
         }
@@ -427,13 +433,22 @@ fun ImageTextEditorScreen(
     }
 }
 
+// Icon above a small label, matching the iOS app's write-on-image toolbar (SF Symbols
+// plus/textformat/textformat.size/paintpalette there; the closest standard Material
+// icons here), instead of plain text-only buttons.
 @Composable
 private fun androidx.compose.foundation.layout.RowScope.EditorToolButton(
     label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
     panel: EditorPanel,
     onClick: (EditorPanel) -> Unit,
 ) {
-    OutlinedButton(onClick = { onClick(panel) }, modifier = Modifier.weight(1f)) { Text(label) }
+    OutlinedButton(onClick = { onClick(panel) }, modifier = Modifier.weight(1f)) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))
+            Text(label, style = MaterialTheme.typography.labelSmall)
+        }
+    }
 }
 
 private fun overlayPaint(typeface: Typeface, textSize: Float, textColor: Int) = Paint(Paint.ANTI_ALIAS_FLAG).apply {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/TrueTypeGenerator.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/TrueTypeGenerator.kt
@@ -9,7 +9,8 @@ class TrueTypeGenerator {
     fun generate(drawings: Collection<GlyphDrawing>, spaceWidthMm: Float = 3f, letterSpacingMm: Float = 0f, fontName: String = "My Hand Font"): ByteArray {
         val space = GlyphDrawing(32, emptyList(), 1f, 1f)
         val ordered = (drawings.filter { it.codePoint in 33..126 } + space).sortedBy { it.codePoint }
-        val glyphs = listOf(notdefGlyph()) + ordered.map(::drawingGlyph)
+        val orderedContours = ordered.map(::glyphContours)
+        val glyphs = listOf(notdefGlyph()) + orderedContours.map(::simpleGlyph)
         val glyf = Bytes()
         val offsets = mutableListOf(0)
         glyphs.forEach {
@@ -24,7 +25,7 @@ class TrueTypeGenerator {
         tables["glyf"] = glyf.toByteArray()
         tables["head"] = head()
         tables["hhea"] = hhea(glyphs.size)
-        tables["hmtx"] = hmtx(ordered, spaceWidthMm, letterSpacingMm)
+        tables["hmtx"] = hmtx(ordered, orderedContours, spaceWidthMm, letterSpacingMm)
         tables["loca"] = Bytes().apply { offsets.forEach(::u32) }.toByteArray()
         tables["maxp"] = maxp(glyphs.size, glyphs.maxOfOrNull(::contourCount) ?: 0)
         tables["name"] = name(fontName)
@@ -34,7 +35,9 @@ class TrueTypeGenerator {
 
     private data class P(val x: Int, val y: Int)
 
-    private fun drawingGlyph(drawing: GlyphDrawing): ByteArray {
+    /** The glyph's outline contours in font-unit space -- used both to build its `glyf` entry
+     *  and (via their ink bounding box) to size its `hmtx` advance width proportionally. */
+    private fun glyphContours(drawing: GlyphDrawing): List<List<P>> {
         val width = drawing.canvasWidth.coerceAtLeast(1f)
         val height = drawing.canvasHeight.coerceAtLeast(1f)
         val baseline = height * .78f
@@ -43,7 +46,7 @@ class TrueTypeGenerator {
             (p.x / width * 1600 + 180).roundToInt().coerceIn(-32768, 32767),
             ((baseline - p.y) * scale).roundToInt().coerceIn(-450, 1900),
         )
-        val contours = drawing.strokes.mapNotNull { stroke ->
+        return drawing.strokes.mapNotNull { stroke ->
             val source = stroke.points.map(::convert).distinct()
             if (source.size < 2) return@mapNotNull null
             val radius = glyphStrokeRadius(drawing.strokeWidth).toDouble()
@@ -62,7 +65,6 @@ class TrueTypeGenerator {
             }
             ensureClockwise(left + right.asReversed())
         }
-        return simpleGlyph(contours)
     }
 
     private fun notdefGlyph(): ByteArray = simpleGlyph(listOf(ensureClockwise(listOf(
@@ -117,12 +119,22 @@ class TrueTypeGenerator {
         u16(0); u16(0); u16(0); u16(0)
     }.toByteArray()
 
-    private fun hmtx(drawings: List<GlyphDrawing>, spaceWidthMm: Float, letterSpacingMm: Float) = Bytes().apply {
+    private fun hmtx(drawings: List<GlyphDrawing>, contours: List<List<List<P>>>, spaceWidthMm: Float, letterSpacingMm: Float) = Bytes().apply {
         u16(2048); s16(0) // .notdef
-        drawings.forEach {
+        // Margin kept on each side of a glyph's actual ink, in font units -- so a narrow "i"
+        // or "r" advances only as far as its own drawn width needs, instead of every glyph
+        // (previously a flat 2048, the full em) reserving the same space regardless of how
+        // little of it a narrow letter's ink actually uses.
+        val sideBearing = 130f
+        drawings.zip(contours).forEach { (drawing, glyphContours) ->
             // At the font's nominal 12 pt size, 1 mm is approximately 484 font units.
-            val advance = if (it.codePoint == 32) (spaceWidthMm * 484f).roundToInt().coerceIn(100, 4096)
-                else (2048 + letterSpacingMm * 484f).roundToInt().coerceIn(500, 4096)
+            val advance = if (drawing.codePoint == 32) {
+                (spaceWidthMm * 484f).roundToInt().coerceIn(100, 4096)
+            } else {
+                val xs = glyphContours.flatten().map { it.x }
+                val inkWidth = ((xs.maxOrNull() ?: 0) - (xs.minOrNull() ?: 0)).toFloat()
+                (inkWidth + sideBearing * 2 + letterSpacingMm * 484f).roundToInt().coerceIn(500, 4096)
+            }
             u16(advance); s16(0)
         }
     }.toByteArray()


### PR DESCRIPTION
## Summary
Ports three fixes from the iOS counterpart app (`jaafar-fonts-ios` PR #38) to this Android app, adapted to this codebase's structure.

**1. Proportional advance widths so narrow letters don't over-space** (`fontcreator/TrueTypeGenerator.kt`)
- `hmtx()` gave every non-space glyph the exact same fixed advance width — a full 2048-unit em, the entire glyph coordinate space — regardless of how wide the letter was actually drawn. A narrow "i" or "r" advanced just as far as a wide "m" or "w".
- `hmtx()` now measures each glyph's actual ink bounding box (reusing the same contours already built for its `glyf` entry) and sets the advance to that ink width plus a fixed side margin, so spacing is proportional to what was actually drawn. `letterSpacingMm` keeps working the same way, added on top of the computed width instead of the old flat 2048.

**2. Pick the most recently created or modified font for dashboard defaults** (`FontModels.kt`, `GlyphRepository.kt`, `FontCreatorViewModel.kt`, `DashboardScreen.kt`)
- `createProject` appends new projects to the end of `projects`, so the dashboard's "Continue" card (`indexOfFirst`) and "Use font on image" (`lastOrNull`) only ever reflected creation order — editing an older, already-drawn font never bubbled it back up as the preferred default.
- Added `FontProject.lastModifiedAt`, stamped centrally in the two shared mutation helpers (`updateActive`, `syncActive`) so rename/spacing/language/drawing-save edits all keep it current without each call site needing to remember to. `GlyphRepository` persists it (missing on old saved data defaults to 0, sorting untouched legacy projects last). Both dashboard defaults now pick by `lastModifiedAt` instead of list position.
- Note: unlike the iOS version of this fix, Android's font rename is dialog-confirm-based, not live-per-keystroke, so it never had iOS's specific "reordering broke mid-rename" bug — this port only carries over the recency-tracking improvement, not a reordering revert.

**3. Write on image: icon+label toolbar buttons, matching iOS** (`ImageTextEditorScreen.kt`)
- Text/Font/Size/Color were plain text-only buttons. Added an icon above each label (`TextFields`/`FontDownload`/`FormatSize`/`Palette` — the closest standard Material icons to the SF Symbols the iOS toolbar uses), matching that app's icon-forward style.

## Notes
- I could not run a full Gradle build to verify these changes compile — this environment's network policy blocks `dl.google.com` (Android Gradle Plugin's Maven repo), so `gradle compileDebugKotlin` fails to resolve the plugin regardless of network reachability otherwise. I did careful manual review instead; all three changes mirror patterns already used elsewhere in the same files (data class `.copy()`, `withIndex()`/`filter()`/`maxByOrNull()` on standard `List`, `Icon`/`Column` Compose usage). Please have CI or a local build confirm before merging.
- Android's `ImageTextEditorScreen.kt` is a single free-text overlay, not the multi-layer text tool iOS's screen has become (iOS's "Add"/multi-layer support was added in iOS-only PRs) — this PR only matches the icon *styling* of the existing four buttons, not a full feature port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz

---
_Generated by [Claude Code](https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz)_