### PR TITLE
Match iOS: richer fonts list rows + icon-only toolbar actions

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -654,18 +654,21 @@ private fun FillMarkEditorScreen(
             }
         },
     ) {
-        // This Column does NOT scroll — only the document area and the config panel (each
-        // independently) do. fillAvailableHeight = false above already stops Page's own
-        // column from forcing full height; this one just wraps its content the same way.
-        Column(Modifier.fillMaxWidth()) {
+        // A single scroll for the whole thing (document + page nav + config panel), instead of
+        // separate weight(1f, fill=false) regions for the document and the config panel: even
+        // with fill=false, Compose's Column still reserves each weighted child's full share of
+        // the Scaffold's bounded content height when sizing the Column itself, so a short config
+        // panel left the rest of its reserved share as blank space above the pinned toolbar.
+        // Plain sequential children wrapped in one shared scroll size to their actual content
+        // instead, and fillAvailableHeight = false above already stops Page's own column from
+        // forcing full height on top of that.
+        Column(Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
 
             // ── DOCUMENT WORKSPACE ───────────────────────────────────────────── ─────────────────────────────────────────
             Box(
                 Modifier
                     .fillMaxWidth()
-                    .weight(1f, fill = false)
-                    .heightIn(min = 200.dp)
-                    .verticalScroll(rememberScrollState()),
+                    .heightIn(min = 200.dp),
             ) {
                 val bitmap = previewBitmap
                 if (bitmap != null) {
@@ -826,15 +829,12 @@ private fun FillMarkEditorScreen(
             // ── CONFIG PANEL ───────────────────────────────────────
             // Color/size/font (and everything else specific to the active tool or the
             // selected mark) live here, inline, right under the document -- not behind an
-            // Edit tap or a bottom sheet. Its own weight+scroll is independent of the
-            // document's above, so a long list (e.g. many saved signatures) scrolls in place
-            // instead of pushing the pinned tool row off-screen.
+            // Edit tap or a bottom sheet. It shares the single scroll above with the document,
+            // so it sizes to its own content instead of reserving a fixed share of the screen.
             if (configuringTool != null) {
                 Column(
                     Modifier
                         .fillMaxWidth()
-                        .weight(1f, fill = false)
-                        .verticalScroll(rememberScrollState())
                         .padding(vertical = 6.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -29,11 +29,14 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Approval
@@ -55,7 +58,6 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -77,6 +79,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color as ComposeColor
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
@@ -86,11 +89,15 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -101,6 +108,7 @@ import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlin.math.roundToInt
 
 // ---------------------------------------------------------------------------
 // Data model
@@ -458,7 +466,9 @@ private fun FillMarkEditorScreen(
             offsetY = offsetY,
             sizeFraction = configSizeFraction,
             text = when (tool) {
-                MarkType.Text -> configText.ifBlank { "Text" }
+                // Starts empty -- the on-canvas overlay opens focused right after placement,
+                // ready for the user to type into, like a fresh input field.
+                MarkType.Text -> configText
                 MarkType.Date -> todayText
                 MarkType.Check -> ""
                 MarkType.Signature, MarkType.Stamp -> ""
@@ -495,7 +505,7 @@ private fun FillMarkEditorScreen(
         }
         marks[idx] = m.copy(
             text = when (m.type) {
-                MarkType.Text -> configText.ifBlank { "Text" }
+                MarkType.Text -> configText
                 MarkType.Date -> m.text
                 MarkType.Check -> ""
                 MarkType.Signature, MarkType.Stamp -> ""
@@ -701,9 +711,26 @@ private fun FillMarkEditorScreen(
                             val w = size.width
                             val h = size.height
                             visibleMarks.forEach { mark ->
+                                // The actively-edited text mark is skipped here -- the overlay
+                                // below renders its live text directly instead, so drawing it
+                                // here too would just double it up underneath the overlay.
+                                if (mark.type == MarkType.Text && mark.id == selectedMarkId) return@forEach
                                 val isSelected = mark.id == selectedMarkId
                                 drawMarkOnCanvas(mark, w, h, isSelected, fontOptions, sigBitmapCache)
                             }
+                        }
+                        // Text is typed directly on the document, right where it will appear --
+                        // matching "Use font on image" -- instead of in a separate field in the
+                        // config panel below.
+                        if (selectedMark != null && selectedMark.type == MarkType.Text && canvasDisplaySize.width > 0) {
+                            TextMarkOverlay(
+                                mark = selectedMark,
+                                canvasSize = canvasDisplaySize,
+                                text = configText,
+                                onTextChange = { configText = it; updateSelectedMark() },
+                                color = textColors.getOrNull(configColorIdx)?.second ?: Color.BLACK,
+                                typeface = fontOptions.getOrNull(configFontIdx)?.second,
+                            )
                         }
                     }
                 } else {
@@ -714,8 +741,10 @@ private fun FillMarkEditorScreen(
                 }
             }
 
-            // PDF page navigation
-            if (isPdf && pageCount > 0) {
+            // PDF page navigation -- hidden for a single-page PDF (or a plain image, where
+            // pageCount is 0), since a "Page 1 of 1" row with two disabled arrows was just
+            // wasted space; the document area is already scrollable on its own.
+            if (isPdf && pageCount > 1) {
                 Row(
                     Modifier.fillMaxWidth().padding(top = 6.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -758,8 +787,6 @@ private fun FillMarkEditorScreen(
                     )
                     MarkConfigPanel(
                         tool = configuringTool,
-                        configText = configText,
-                        onConfigTextChange = { configText = it },
                         configColorIdx = configColorIdx,
                         onColorChange = { configColorIdx = it; updateSelectedMark() },
                         textColors = textColors,
@@ -836,6 +863,53 @@ private fun MarkToolContent(label: String, icon: androidx.compose.ui.graphics.ve
 }
 
 /**
+ * A live text field positioned and sized to match exactly where [drawMarkOnCanvas] would draw
+ * this text mark, so typing happens directly on the document -- the same "Use font on image"
+ * experience -- instead of in a separate field elsewhere on the screen. The mark it belongs to
+ * is skipped in the Canvas draw loop while this is on screen, so there's no double-render.
+ */
+@Composable
+private fun TextMarkOverlay(
+    mark: DocumentMark,
+    canvasSize: IntSize,
+    text: String,
+    onTextChange: (String) -> Unit,
+    color: Int,
+    typeface: Typeface?,
+) {
+    val density = LocalDensity.current
+    val focusRequester = remember(mark.id) { FocusRequester() }
+    val w = canvasSize.width.toFloat()
+    val h = canvasSize.height.toFloat()
+    val left = mark.offsetX * w
+    val top = mark.offsetY * h
+    // Matches drawMarkOnCanvas's own textSizePx/left/top so the live field lines up with where
+    // the static text would otherwise have been drawn.
+    val textSizePx = mark.sizeFraction * w * 0.25f
+    val maxWidthPx = (w - left).coerceAtLeast(textSizePx * 4f)
+    BasicTextField(
+        value = text,
+        onValueChange = onTextChange,
+        singleLine = true,
+        textStyle = TextStyle(
+            color = ComposeColor(color),
+            fontSize = with(density) { textSizePx.toSp() },
+            fontFamily = typeface?.let { FontFamily(it) },
+        ),
+        cursorBrush = SolidColor(ComposeColor(color)),
+        modifier = Modifier
+            .offset { IntOffset(left.roundToInt(), top.roundToInt()) }
+            .widthIn(
+                min = with(density) { (textSizePx * 3f).toDp() },
+                max = with(density) { maxWidthPx.toDp() },
+            )
+            .background(ComposeColor.White.copy(alpha = .6f))
+            .focusRequester(focusRequester),
+    )
+    LaunchedEffect(mark.id) { focusRequester.requestFocus() }
+}
+
+/**
  * Draws a three-node share/network graph icon (three dots connected by two lines)
  * without requiring the material-icons-extended library.
  */
@@ -870,8 +944,6 @@ private enum class MarkControl { Color, Font, Size, CheckStyle, Asset, ApplyToAl
 @Composable
 private fun MarkConfigPanel(
     tool: MarkType,
-    configText: String,
-    onConfigTextChange: (String) -> Unit,
     configColorIdx: Int,
     onColorChange: (Int) -> Unit,
     textColors: List<Pair<String, Int>>,
@@ -904,30 +976,10 @@ private fun MarkConfigPanel(
             .padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        // Content that's always visible for this mark type, regardless of which control (if
-        // any) is expanded below.
-        when (tool) {
-            MarkType.Text -> {
-                val textFieldFocusRequester = remember { FocusRequester() }
-                OutlinedTextField(
-                    value = configText,
-                    onValueChange = onConfigTextChange,
-                    modifier = Modifier.fillMaxWidth().focusRequester(textFieldFocusRequester),
-                    label = { Text("Text") },
-                    singleLine = true,
-                )
-                if (selectedMark == null) {
-                    // Open with the keyboard already up when placing a new text mark, so the
-                    // user can start typing immediately instead of having to tap the field first.
-                    LaunchedEffect(Unit) { textFieldFocusRequester.requestFocus() }
-                }
-            }
-            MarkType.Date -> {
-                val today = remember { SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).format(Date()) }
-                Text("Date: $today", style = MaterialTheme.typography.bodySmall)
-            }
-            MarkType.Check, MarkType.Signature, MarkType.Stamp -> Unit
-        }
+        // Text has no field here anymore -- typing happens directly on the document itself,
+        // in a text field overlaid right where the mark sits (same as "Use font on image").
+        // Date needs nothing here either: the placed mark on the document already shows
+        // today's date, so a second preview of it in this panel was redundant.
 
         // Icon toolbar -- one icon per control; tapping one reveals just that control below,
         // e.g. tapping the font icon shows the font list, instead of a fixed block of every

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -869,20 +870,15 @@ private fun FillMarkEditorScreen(
                         configApplyToAll = configApplyToAll,
                         onApplyToAllChange = { configApplyToAll = it; updateSelectedMark() },
                         selectedMark = selectedMark,
-                    )
-                    if (selectedMark != null) {
-                        TextButton(onClick = {
-                            marks.removeIf { it.id == selectedMarkId }
-                            selectedMarkId = null
-                            activeTool = null
-                            editingTextMarkId = null
-                        }) {
-                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
-                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
-                                Text("Delete mark")
+                        onDelete = if (selectedMark != null) {
+                            {
+                                marks.removeIf { it.id == selectedMarkId }
+                                selectedMarkId = null
+                                activeTool = null
+                                editingTextMarkId = null
                             }
-                        }
-                    }
+                        } else null,
+                    )
                 }
             }
 
@@ -1009,6 +1005,7 @@ private fun MarkConfigPanel(
     configApplyToAll: Boolean,
     onApplyToAllChange: (Boolean) -> Unit,
     selectedMark: DocumentMark?,
+    onDelete: (() -> Unit)? = null,
 ) {
     // Which control (if any) is expanded below the icon row -- only one at a time, so this
     // panel stays compact instead of showing color+font+size+... all at once.
@@ -1032,7 +1029,7 @@ private fun MarkConfigPanel(
         // Icon toolbar -- one icon per control; tapping one reveals just that control below,
         // e.g. tapping the font icon shows the font list, instead of a fixed block of every
         // control at once.
-        Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(2.dp)) {
             when (tool) {
                 MarkType.Text, MarkType.Date, MarkType.Check -> {
                     if (tool == MarkType.Check) {
@@ -1054,6 +1051,14 @@ private fun MarkConfigPanel(
                     if (isPdf) {
                         ControlIconButton(Icons.Filled.Layers, "Apply to all pages", expandedControl == MarkControl.ApplyToAll) { toggle(MarkControl.ApplyToAll) }
                     }
+                }
+            }
+            // Delete sits at the far right of the same row, away from the other controls,
+            // instead of its own row below the panel.
+            if (onDelete != null) {
+                Spacer(Modifier.weight(1f))
+                IconButton(onClick = onDelete) {
+                    Icon(Icons.Filled.Delete, contentDescription = "Delete mark", tint = MaterialTheme.colorScheme.error)
                 }
             }
         }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -41,12 +41,10 @@ import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Draw
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -338,7 +336,6 @@ private fun FillMarkEditorScreen(
     val marks = remember { mutableStateListOf<DocumentMark>() }
     var selectedMarkId by remember { mutableStateOf<Long?>(null) }
     var activeTool by remember { mutableStateOf<MarkType?>(null) }
-    var showMarkOptions by remember { mutableStateOf(false) }
 
     // Per-tool config state (shared across marks for ergonomics)
     var configText by remember { mutableStateOf(initialText ?: "") }
@@ -537,76 +534,11 @@ private fun FillMarkEditorScreen(
         }
     }
 
-    if (showMarkOptions && activeTool != null) {
-        ModalBottomSheet(onDismissRequest = { showMarkOptions = false }) {
-            Column(
-                Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                Text(
-                    if (selectedMark == null) "Add ${activeTool!!.label}" else "Edit ${activeTool!!.label}",
-                    style = MaterialTheme.typography.titleLarge,
-                )
-                MarkConfigPanel(
-                        tool = activeTool!!,
-                        configText = configText,
-                        onConfigTextChange = { configText = it },
-                        configColorIdx = configColorIdx,
-                        onColorChange = { configColorIdx = it; updateSelectedMark() },
-                        textColors = textColors,
-                        configFontIdx = configFontIdx,
-                        onFontChange = { configFontIdx = it; updateSelectedMark() },
-                        fontOptions = fontOptions,
-                        configSizeFraction = configSizeFraction,
-                        onSizeChange = { configSizeFraction = it; updateSelectedMark() },
-                        configCheckStyle = configCheckStyle,
-                        onCheckStyleChange = { configCheckStyle = it; updateSelectedMark() },
-                        configSignatureName = configSignatureName,
-                        onSignatureChange = {
-                            configSignatureName = it
-                            when (activeTool) {
-                                MarkType.Signature -> it?.takeIf { name ->
-                                    vm.signatures.any { signature -> signature.imageFileName == null && signature.name == name }
-                                }?.let(vm::setDefaultSignature)
-                                MarkType.Stamp -> it?.takeIf { name ->
-                                    vm.signatures.any { signature -> signature.imageFileName != null && signature.name == name }
-                                }?.let(vm::setDefaultStamp)
-                                else -> Unit
-                            }
-                            updateSelectedMark()
-                        },
-                        vm = vm,
-                        isPdf = isPdf,
-                        configApplyToAll = configApplyToAll,
-                        onApplyToAllChange = { configApplyToAll = it; updateSelectedMark() },
-                        selectedMark = selectedMark,
-                    )
-                if (selectedMark != null) {
-                    TextButton(onClick = {
-                        marks.removeIf { it.id == selectedMarkId }
-                        selectedMarkId = null
-                        activeTool = null
-                        showMarkOptions = false
-                    }) { Text("Delete mark") }
-                }
-                Button(
-                    onClick = {
-                        updateSelectedMark()
-                        if (selectedMark != null) activeTool = null
-                        showMarkOptions = false
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(
-                        if (selectedMark == null) "Place on document" else "Done",
-                    )
-                }
-            }
-        }
-    }
+    // The active tool (adding a new mark) or the selected mark (editing an existing one) --
+    // whichever applies decides what MarkConfigPanel below configures. Shown inline in the
+    // screen itself (under the document, above the pinned tool row) instead of in a bottom
+    // sheet, so color/size/font are visible and adjustable without covering the canvas.
+    val configuringTool = activeTool ?: selectedMark?.type
 
     Page(
         title = "Fill & Mark Document",
@@ -620,8 +552,67 @@ private fun FillMarkEditorScreen(
                 FillMarkShareIcon()
             }
         },
+        bottomBar = {
+            // Text/Date/Check/Sign/Stamp stay pinned to the very bottom of the screen at all
+            // times, regardless of how much the document or the config panel above take up.
+            Column(Modifier.fillMaxWidth()) {
+                HorizontalDivider()
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    val isTextMode = activeTool == MarkType.Text
+                    if (isTextMode) {
+                        OutlinedButton(onClick = {
+                            activeTool = null
+                            selectedMarkId = null
+                        }) { MarkToolContent("Text", Icons.Filled.TextFields) }
+                    } else {
+                        TextButton(onClick = {
+                            configText = ""
+                            selectedMarkId = null
+                            activeTool = MarkType.Text
+                        }) { MarkToolContent("Text", Icons.Filled.TextFields) }
+                    }
+                    availableTools.filter { it != MarkType.Text }.forEach { tool ->
+                        val compactLabel = when (tool) {
+                            MarkType.Date -> "Date"
+                            MarkType.Check -> "Check"
+                            MarkType.Signature -> "Sign"
+                            MarkType.Stamp -> "Stamp"
+                            MarkType.Text -> error("Text is handled above")
+                        }
+                        val icon = when (tool) {
+                            MarkType.Date -> Icons.Filled.CalendarToday
+                            MarkType.Check -> Icons.Filled.Check
+                            MarkType.Signature -> Icons.Filled.Draw
+                            MarkType.Stamp -> Icons.Filled.Approval
+                            MarkType.Text -> error("Text is handled above")
+                        }
+                        val isActive = activeTool == tool
+                        if (isActive) {
+                            OutlinedButton(onClick = { activeTool = null; selectedMarkId = null }) { MarkToolContent(compactLabel, icon) }
+                        } else {
+                            TextButton(onClick = {
+                                activeTool = tool
+                                configSignatureName = when (tool) {
+                                    MarkType.Signature -> defaultSignatureName
+                                    MarkType.Stamp -> defaultStampName
+                                    else -> configSignatureName
+                                }
+                                selectedMarkId = null
+                            }) { MarkToolContent(compactLabel, icon) }
+                        }
+                    }
+                }
+            }
+        },
     ) {
-        // The outer Column does NOT scroll — only the document area scrolls.
+        // The outer Column does NOT scroll — only the document area and the config panel
+        // (each independently) do.
         Column(Modifier.fillMaxSize()) {
 
             // ── DOCUMENT WORKSPACE ───────────────────────────────────────────── ─────────────────────────────────────────
@@ -719,121 +710,101 @@ private fun FillMarkEditorScreen(
                 }
             }
 
-            // ── COMPACT MARK BAR ─────────────────────────────────────────────── ────────────────────────────────────────────
-            Column(
-                Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 4.dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                // Edit/Delete for the selected mark -- placed directly under the document,
-                // above the tool selector row, so it sits right next to what it acts on.
-                if (selectedMark != null) {
-                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        OutlinedButton(onClick = { activeTool = selectedMark.type; showMarkOptions = true }, modifier = Modifier.weight(1f)) {
-                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
-                                Icon(Icons.Filled.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
-                                Text("Edit")
-                            }
-                        }
-                        TextButton(onClick = { marks.removeIf { it.id == selectedMarkId }; selectedMarkId = null; activeTool = null }, modifier = Modifier.weight(1f)) {
-                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
-                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
-                                Text("Delete")
-                            }
-                        }
-                    }
-                }
-
-                // PDF page navigation
-                if (isPdf && pageCount > 0) {
-                    Row(
-                        Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        OutlinedButton(
-                            onClick = { if (currentPage > 0) currentPage-- },
-                            enabled = currentPage > 0,
-                        ) { Text("\u2190") }
-                        Text(
-                            "Page ${currentPage + 1} of $pageCount",
-                            modifier = Modifier.weight(1f),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                        OutlinedButton(
-                            onClick = { if (currentPage < pageCount - 1) currentPage++ },
-                            enabled = currentPage < pageCount - 1,
-                        ) { Text("\u2192") }
-                    }
-                }
-
-                // Tool selector toolbar
-                HorizontalDivider()
+            // PDF page navigation
+            if (isPdf && pageCount > 0) {
                 Row(
+                    Modifier.fillMaxWidth().padding(top = 6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    OutlinedButton(
+                        onClick = { if (currentPage > 0) currentPage-- },
+                        enabled = currentPage > 0,
+                    ) { Text("\u2190") }
+                    Text(
+                        "Page ${currentPage + 1} of $pageCount",
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    OutlinedButton(
+                        onClick = { if (currentPage < pageCount - 1) currentPage++ },
+                        enabled = currentPage < pageCount - 1,
+                    ) { Text("\u2192") }
+                }
+            }
+
+            // ── CONFIG PANEL ───────────────────────────────────────
+            // Color/size/font (and everything else specific to the active tool or the
+            // selected mark) live here, inline, right under the document -- not behind an
+            // Edit tap or a bottom sheet. Its own weight+scroll is independent of the
+            // document's above, so a long list (e.g. many saved signatures) scrolls in place
+            // instead of pushing the pinned tool row off-screen.
+            if (configuringTool != null) {
+                Column(
                     Modifier
                         .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        .weight(1f, fill = false)
+                        .verticalScroll(rememberScrollState())
+                        .padding(vertical = 6.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    val isTextMode = activeTool == MarkType.Text
-                    if (isTextMode) {
-                        OutlinedButton(onClick = {
-                            activeTool = null
-                            selectedMarkId = null
-                        }) { MarkToolContent("Text", Icons.Filled.TextFields) }
-                    } else {
-                        // Same full config panel (color/size/font) as every other tool below,
-                        // instead of the old bare text-only sheet, so styling is available
-                        // right away instead of only after the mark is placed and re-edited.
-                        TextButton(onClick = {
-                            configText = ""
-                            selectedMarkId = null
-                            activeTool = MarkType.Text
-                            showMarkOptions = true
-                        }) { MarkToolContent("Text", Icons.Filled.TextFields) }
-                    }
-                    availableTools.filter { it != MarkType.Text }.forEach { tool ->
-                        val compactLabel = when (tool) {
-                            MarkType.Date -> "Date"
-                            MarkType.Check -> "Check"
-                            MarkType.Signature -> "Sign"
-                            MarkType.Stamp -> "Stamp"
-                            MarkType.Text -> error("Text is handled above")
-                        }
-                        val icon = when (tool) {
-                            MarkType.Date -> Icons.Filled.CalendarToday
-                            MarkType.Check -> Icons.Filled.Check
-                            MarkType.Signature -> Icons.Filled.Draw
-                            MarkType.Stamp -> Icons.Filled.Approval
-                            MarkType.Text -> error("Text is handled above")
-                        }
-                        val isActive = activeTool == tool
-                        if (isActive) {
-                            OutlinedButton(onClick = { activeTool = null; selectedMarkId = null }) { MarkToolContent(compactLabel, icon) }
-                        } else {
-                            TextButton(onClick = {
-                                activeTool = tool
-                                configSignatureName = when (tool) {
-                                    MarkType.Signature -> defaultSignatureName
-                                    MarkType.Stamp -> defaultStampName
-                                    else -> configSignatureName
-                                }
-                                selectedMarkId = null
-                                showMarkOptions = true
-                            }) { MarkToolContent(compactLabel, icon) }
-                        }
-                    }
-                }
-
-                if (activeTool != null && activeTool != MarkType.Text) {
                     Text(
-                        "Tap the document to place ${activeTool!!.label.lowercase()}.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary,
+                        if (selectedMark == null) "Add ${configuringTool.label}" else "Edit ${configuringTool.label}",
+                        style = MaterialTheme.typography.titleMedium,
                     )
+                    MarkConfigPanel(
+                        tool = configuringTool,
+                        configText = configText,
+                        onConfigTextChange = { configText = it },
+                        configColorIdx = configColorIdx,
+                        onColorChange = { configColorIdx = it; updateSelectedMark() },
+                        textColors = textColors,
+                        configFontIdx = configFontIdx,
+                        onFontChange = { configFontIdx = it; updateSelectedMark() },
+                        fontOptions = fontOptions,
+                        configSizeFraction = configSizeFraction,
+                        onSizeChange = { configSizeFraction = it; updateSelectedMark() },
+                        configCheckStyle = configCheckStyle,
+                        onCheckStyleChange = { configCheckStyle = it; updateSelectedMark() },
+                        configSignatureName = configSignatureName,
+                        onSignatureChange = {
+                            configSignatureName = it
+                            when (configuringTool) {
+                                MarkType.Signature -> it?.takeIf { name ->
+                                    vm.signatures.any { signature -> signature.imageFileName == null && signature.name == name }
+                                }?.let(vm::setDefaultSignature)
+                                MarkType.Stamp -> it?.takeIf { name ->
+                                    vm.signatures.any { signature -> signature.imageFileName != null && signature.name == name }
+                                }?.let(vm::setDefaultStamp)
+                                else -> Unit
+                            }
+                            updateSelectedMark()
+                        },
+                        vm = vm,
+                        isPdf = isPdf,
+                        configApplyToAll = configApplyToAll,
+                        onApplyToAllChange = { configApplyToAll = it; updateSelectedMark() },
+                        selectedMark = selectedMark,
+                    )
+                    if (selectedMark != null) {
+                        TextButton(onClick = {
+                            marks.removeIf { it.id == selectedMarkId }
+                            selectedMarkId = null
+                            activeTool = null
+                        }) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                                Text("Delete mark")
+                            }
+                        }
+                    } else {
+                        Text(
+                            "Tap the document to place ${configuringTool.label.lowercase()}.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                 }
-                HorizontalDivider()
             }
 
             // ── FIXED BOTTOM (export status) ─────────────────────────────────────

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -692,11 +692,16 @@ private fun FillMarkEditorScreen(
                                             hitMark != null -> {
                                                 selectedMarkId = hitMark.id
                                                 drag(down.id) { change ->
+                                                    // positionChange() returns Offset.Zero once the
+                                                    // change is consumed, so it must be read before
+                                                    // consume() -- reading it after (as an earlier
+                                                    // version of this code did) silently zeroed out
+                                                    // every drag delta and made dragging a no-op.
+                                                    val delta = change.positionChange()
                                                     change.consume()
                                                     val idx = marks.indexOfFirst { it.id == hitMark.id }
                                                     if (idx >= 0) {
                                                         val m = marks[idx]
-                                                        val delta = change.positionChange()
                                                         marks[idx] = m.copy(
                                                             offsetX = (m.offsetX + delta.x / w).coerceIn(0f, 1f),
                                                             offsetY = (m.offsetY + delta.y / h).coerceIn(0f, 1f),

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -109,6 +109,7 @@ import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlin.math.hypot
 import kotlin.math.roundToInt
 
 // ---------------------------------------------------------------------------
@@ -718,7 +719,13 @@ private fun FillMarkEditorScreen(
                                         when {
                                             hitMark != null -> {
                                                 selectedMarkId = hitMark.id
-                                                var moved = false
+                                                // Total displacement from the initial touch-down,
+                                                // used below to tell a genuine drag from a tap --
+                                                // drag() itself has no slop tolerance, so even the
+                                                // tiny sensor jitter a real finger-tap produces
+                                                // would otherwise count as "moved" on every tap,
+                                                // permanently defeating single/double-tap detection.
+                                                var totalDrag = Offset.Zero
                                                 drag(down.id) { change ->
                                                     // positionChange() returns Offset.Zero once the
                                                     // change is consumed, so it must be read before
@@ -727,7 +734,7 @@ private fun FillMarkEditorScreen(
                                                     // every drag delta and made dragging a no-op.
                                                     val delta = change.positionChange()
                                                     change.consume()
-                                                    if (delta != Offset.Zero) moved = true
+                                                    totalDrag += delta
                                                     val idx = marks.indexOfFirst { it.id == hitMark.id }
                                                     if (idx >= 0) {
                                                         val m = marks[idx]
@@ -737,6 +744,7 @@ private fun FillMarkEditorScreen(
                                                         )
                                                     }
                                                 }
+                                                val moved = hypot(totalDrag.x, totalDrag.y) > viewConfiguration.touchSlop
                                                 // A plain tap (no movement) on a text mark either
                                                 // opens it for editing (double-tap) or just selects
                                                 // it to show the config panel (single tap) -- a drag

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -557,6 +557,9 @@ private fun FillMarkEditorScreen(
     Page(
         title = "Fill & Mark Document",
         back = back,
+        // The document and config panel below both shrink to their own content -- a
+        // full-height column here would just leave blank space above the pinned bottomBar.
+        fillAvailableHeight = false,
         actions = {
             // Share / Export icon button fixed in the top app bar.
             IconButton(
@@ -625,12 +628,9 @@ private fun FillMarkEditorScreen(
             }
         },
     ) {
-        // The outer Column does NOT scroll — only the document area and the config panel
-        // (each independently) do. Deliberately NOT fillMaxSize(): the document and config
-        // panel below both shrink to their own content (weight(fill = false)), and forcing
-        // this Column to the full available height left the leftover space as a blank gap
-        // between the config panel and the pinned bottomBar. Sizing to actual content instead
-        // means the column ends exactly where its content ends.
+        // This Column does NOT scroll — only the document area and the config panel (each
+        // independently) do. fillAvailableHeight = false above already stops Page's own
+        // column from forcing full height; this one just wraps its content the same way.
         Column(Modifier.fillMaxWidth()) {
 
             // ── DOCUMENT WORKSPACE ───────────────────────────────────────────── ─────────────────────────────────────────

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -824,14 +824,9 @@ private fun FillMarkEditorScreen(
             }
 
             // ── FIXED BOTTOM (export status) ─────────────────────────────────────
-            if (marks.isNotEmpty() && !isProcessing) {
-                Button(
-                    onClick = ::triggerExport,
-                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                ) {
-                    Text("Export & Share")
-                }
-            }
+            // Export/share is triggered from the top app bar's icon button only -- this
+            // full-width "Export & Share" button called the exact same triggerExport(),
+            // just as a second, redundant way to do it.
             if (isProcessing) LinearProgressIndicator(Modifier.fillMaxWidth())
             if (status.isNotBlank()) Text(
                 status,

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -33,8 +33,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Approval
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Draw
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
@@ -744,7 +753,7 @@ private fun FillMarkEditorScreen(
                             activeTool = null
                             selectedMarkId = null
                             showTextEntry = false
-                        }) { Text("Text") }
+                        }) { MarkToolContent("Text", Icons.Filled.TextFields) }
                     } else {
                         TextButton(onClick = {
                             configText = ""
@@ -752,19 +761,26 @@ private fun FillMarkEditorScreen(
                             showMarkOptions = false
                             activeTool = MarkType.Text
                             showTextEntry = true
-                        }) { Text("Text") }
+                        }) { MarkToolContent("Text", Icons.Filled.TextFields) }
                     }
                     availableTools.filter { it != MarkType.Text }.forEach { tool ->
                         val compactLabel = when (tool) {
                             MarkType.Date -> "Date"
-                            MarkType.Check -> "✓"
+                            MarkType.Check -> "Check"
                             MarkType.Signature -> "Sign"
                             MarkType.Stamp -> "Stamp"
                             MarkType.Text -> error("Text is handled above")
                         }
+                        val icon = when (tool) {
+                            MarkType.Date -> Icons.Filled.CalendarToday
+                            MarkType.Check -> Icons.Filled.Check
+                            MarkType.Signature -> Icons.Filled.Draw
+                            MarkType.Stamp -> Icons.Filled.Approval
+                            MarkType.Text -> error("Text is handled above")
+                        }
                         val isActive = activeTool == tool
                         if (isActive) {
-                            OutlinedButton(onClick = { activeTool = null; selectedMarkId = null }) { Text(compactLabel) }
+                            OutlinedButton(onClick = { activeTool = null; selectedMarkId = null }) { MarkToolContent(compactLabel, icon) }
                         } else {
                             TextButton(onClick = {
                                 activeTool = tool
@@ -775,7 +791,7 @@ private fun FillMarkEditorScreen(
                                 }
                                 selectedMarkId = null
                                 showMarkOptions = true
-                            }) { Text(compactLabel) }
+                            }) { MarkToolContent(compactLabel, icon) }
                         }
                     }
                 }
@@ -789,8 +805,18 @@ private fun FillMarkEditorScreen(
                 }
                 if (selectedMark != null) {
                     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        OutlinedButton(onClick = { activeTool = selectedMark.type; showMarkOptions = true }, modifier = Modifier.weight(1f)) { Text("Edit") }
-                        TextButton(onClick = { marks.removeIf { it.id == selectedMarkId }; selectedMarkId = null; activeTool = null }, modifier = Modifier.weight(1f)) { Text("Delete") }
+                        OutlinedButton(onClick = { activeTool = selectedMark.type; showMarkOptions = true }, modifier = Modifier.weight(1f)) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                                Icon(Icons.Filled.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
+                                Text("Edit")
+                            }
+                        }
+                        TextButton(onClick = { marks.removeIf { it.id == selectedMarkId }; selectedMarkId = null; activeTool = null }, modifier = Modifier.weight(1f)) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                                Text("Delete")
+                            }
+                        }
                     }
                 }
 
@@ -813,6 +839,16 @@ private fun FillMarkEditorScreen(
                 modifier = Modifier.padding(top = 4.dp),
             )
         }
+    }
+}
+
+/** Icon above a small label, used by the tool-selector toolbar so each mark type reads by
+ *  icon first instead of by a plain text button. */
+@Composable
+private fun MarkToolContent(label: String, icon: androidx.compose.ui.graphics.vector.ImageVector) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))
+        Text(label, style = MaterialTheme.typography.labelSmall)
     }
 }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.shape.CircleShape
@@ -76,6 +78,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
@@ -633,7 +636,7 @@ private fun FillMarkEditorScreen(
             Box(
                 Modifier
                     .fillMaxWidth()
-                    .weight(1f)
+                    .weight(1f, fill = false)
                     .heightIn(min = 200.dp)
                     .verticalScroll(rememberScrollState()),
             ) {
@@ -658,37 +661,47 @@ private fun FillMarkEditorScreen(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .pointerInput(activeTool, currentPage) {
-                                    detectTapGestures { offset ->
+                                    // A single combined gesture handler -- tap to select/place,
+                                    // then drag the same finger to move a just-selected mark.
+                                    // Previously tap-select and drag-move were two independent
+                                    // pointerInput detectors on the same Canvas; the drag
+                                    // detector's touch-slop handling could consume small,
+                                    // natural finger jitter during a "tap", which cancelled the
+                                    // sibling tap detector and made reselecting an existing mark
+                                    // unreliable.
+                                    awaitEachGesture {
+                                        val down = awaitFirstDown()
                                         val w = canvasDisplaySize.width.toFloat().coerceAtLeast(1f)
                                         val h = canvasDisplaySize.height.toFloat().coerceAtLeast(1f)
-                                        val hit = visibleMarks.lastOrNull { mark ->
-                                            markContainsPoint(mark, offset, w, h)
+                                        val hitMark = visibleMarks.lastOrNull { mark ->
+                                            markContainsPoint(mark, down.position, w, h)
                                         }
                                         when {
-                                            hit != null -> {
-                                                selectedMarkId = hit.id
+                                            hitMark != null -> {
+                                                selectedMarkId = hitMark.id
+                                                drag(down.id) { change ->
+                                                    change.consume()
+                                                    val idx = marks.indexOfFirst { it.id == hitMark.id }
+                                                    if (idx >= 0) {
+                                                        val m = marks[idx]
+                                                        val delta = change.positionChange()
+                                                        marks[idx] = m.copy(
+                                                            offsetX = (m.offsetX + delta.x / w).coerceIn(0f, 1f),
+                                                            offsetY = (m.offsetY + delta.y / h).coerceIn(0f, 1f),
+                                                        )
+                                                    }
+                                                }
                                             }
                                             activeTool != null -> {
-                                                val xFrac = (offset.x / w).coerceIn(0f, 0.85f)
-                                                val yFrac = (offset.y / h).coerceIn(0f, 0.85f)
-                                                addOrUpdateMark(xFrac, yFrac)
+                                                if (waitForUpOrCancellation() != null) {
+                                                    val xFrac = (down.position.x / w).coerceIn(0f, 0.85f)
+                                                    val yFrac = (down.position.y / h).coerceIn(0f, 0.85f)
+                                                    addOrUpdateMark(xFrac, yFrac)
+                                                }
                                             }
-                                            else -> selectedMarkId = null
-                                        }
-                                    }
-                                }
-                                .pointerInput(selectedMarkId) {
-                                    detectDragGestures { change, dragAmount ->
-                                        change.consume()
-                                        val w = canvasDisplaySize.width.toFloat().coerceAtLeast(1f)
-                                        val h = canvasDisplaySize.height.toFloat().coerceAtLeast(1f)
-                                        val idx = marks.indexOfFirst { it.id == selectedMarkId }
-                                        if (idx >= 0) {
-                                            val m = marks[idx]
-                                            marks[idx] = m.copy(
-                                                offsetX = (m.offsetX + dragAmount.x / w).coerceIn(0f, 1f),
-                                                offsetY = (m.offsetY + dragAmount.y / h).coerceIn(0f, 1f),
-                                            )
+                                            else -> {
+                                                if (waitForUpOrCancellation() != null) selectedMarkId = null
+                                            }
                                         }
                                     }
                                 },

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -71,6 +71,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color as ComposeColor
 import androidx.compose.ui.graphics.asImageBitmap
@@ -537,12 +539,22 @@ private fun FillMarkEditorScreen(
     }
 
     if (showTextEntry) {
+        val textFieldFocusRequester = remember { FocusRequester() }
         ModalBottomSheet(onDismissRequest = { showTextEntry = false; activeTool = null }) {
             Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                OutlinedTextField(value = configText, onValueChange = { configText = it }, modifier = Modifier.fillMaxWidth(), placeholder = { Text("Type text") }, singleLine = true)
+                OutlinedTextField(
+                    value = configText,
+                    onValueChange = { configText = it },
+                    modifier = Modifier.fillMaxWidth().focusRequester(textFieldFocusRequester),
+                    placeholder = { Text("Type text") },
+                    singleLine = true,
+                )
                 Button(onClick = { showTextEntry = false }, modifier = Modifier.fillMaxWidth()) { Text("Place on document") }
             }
         }
+        // Open the sheet with the keyboard already up so the user can start typing
+        // immediately instead of having to tap the field first.
+        LaunchedEffect(Unit) { textFieldFocusRequester.requestFocus() }
     }
 
     if (showMarkOptions && activeTool != null) {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -378,6 +378,11 @@ private fun FillMarkEditorScreen(
             "Blue" to Color.BLUE,
             "Red" to Color.RED,
             "Green" to 0xFF006400.toInt(),
+            "Orange" to 0xFFFF8C00.toInt(),
+            "Yellow" to 0xFFF9A825.toInt(),
+            "Purple" to 0xFF9C27B0.toInt(),
+            "Gray" to Color.GRAY,
+            "Brown" to 0xFF795548.toInt(),
         )
     }
 
@@ -1119,7 +1124,9 @@ private fun ControlIconButton(icon: androidx.compose.ui.graphics.vector.ImageVec
 @Composable
 private fun ColorRow(colorIdx: Int, onColorChange: (Int) -> Unit, colors: List<Pair<String, Int>>) {
     Row(
-        Modifier.fillMaxWidth(),
+        Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -715,7 +715,7 @@ private fun FillMarkEditorScreen(
                                         // instead of where the mark visually moved to.
                                         val hitMark = marks
                                             .filter { it.applyToAllPages || it.targetPage == currentPage }
-                                            .lastOrNull { mark -> markContainsPoint(mark, down.position, w, h) }
+                                            .lastOrNull { mark -> markContainsPoint(mark, down.position, w, h, fontOptions) }
                                         when {
                                             hitMark != null -> {
                                                 selectedMarkId = hitMark.id
@@ -1254,15 +1254,49 @@ private fun SignatureStampSelector(
  * Estimates the bounding box of [mark] in canvas-pixel coordinates and tests
  * whether [point] falls inside it.
  */
-private fun markContainsPoint(mark: DocumentMark, point: androidx.compose.ui.geometry.Offset, w: Float, h: Float): Boolean {
+private fun markContainsPoint(
+    mark: DocumentMark,
+    point: androidx.compose.ui.geometry.Offset,
+    w: Float,
+    h: Float,
+    fontOptions: List<Pair<String, Typeface>>,
+): Boolean {
     val left = mark.offsetX * w
     val top = mark.offsetY * h
-    val width = mark.sizeFraction * w
+    val markWidth = mark.sizeFraction * w
+    // Text/Date's hit width must match how far the string actually renders (drawMarkOnCanvas
+    // draws it unclamped) -- markWidth alone is just a font-size estimate, so a longer string
+    // like "one two three" would render well past it, leaving its tail end untappable.
+    val width = when (mark.type) {
+        MarkType.Text, MarkType.Date ->
+            maxOf(markWidth, measuredTextMarkWidth(mark.text, markWidth, mark.fontKey, fontOptions))
+        MarkType.Check, MarkType.Signature, MarkType.Stamp -> markWidth
+    }
     val height = when (mark.type) {
-        MarkType.Text, MarkType.Date, MarkType.Check -> width * 0.5f
-        MarkType.Signature, MarkType.Stamp -> width * 0.7f
+        MarkType.Text, MarkType.Date, MarkType.Check -> markWidth * 0.5f
+        MarkType.Signature, MarkType.Stamp -> markWidth * 0.7f
     }
     return point.x in left..(left + width) && point.y in top..(top + height)
+}
+
+/** Actual rendered width (px) of a Text/Date mark's string, using the same font size and
+ *  typeface drawMarkOnCanvas draws it with -- kept as one shared calculation so hit-testing
+ *  and the selection highlight can't drift out of sync with each other or with the real
+ *  drawn text again. */
+private fun measuredTextMarkWidth(
+    text: String,
+    markWidth: Float,
+    fontKey: String?,
+    fontOptions: List<Pair<String, Typeface>>,
+): Float {
+    val textSizePx = markWidth * 0.25f
+    val paint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+        textSize = textSizePx.coerceAtLeast(8f)
+        if (fontKey != null) {
+            fontOptions.firstOrNull { it.first == fontKey }?.second?.let { typeface = it }
+        }
+    }
+    return paint.measureText(text)
 }
 
 /**
@@ -1297,7 +1331,7 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawMarkOnCanvas(
                 c.nativeCanvas.drawText(displayText, left, top + textSizePx, paint)
             }
             if (isSelected) {
-                val textW = displayText.length * markWidth * 0.15f
+                val textW = measuredTextMarkWidth(displayText, markWidth, mark.fontKey, fontOptions)
                 drawSelectionRect(left, top, textW.coerceAtLeast(markWidth * 0.3f), markWidth * 0.3f)
             }
         }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Draw
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -335,7 +334,6 @@ private fun FillMarkEditorScreen(
     var selectedMarkId by remember { mutableStateOf<Long?>(null) }
     var activeTool by remember { mutableStateOf<MarkType?>(null) }
     var showMarkOptions by remember { mutableStateOf(false) }
-    var showMarkActionsSheet by remember { mutableStateOf(false) }
 
     // Per-tool config state (shared across marks for ergonomics)
     var configText by remember { mutableStateOf(initialText ?: "") }
@@ -615,42 +613,6 @@ private fun FillMarkEditorScreen(
         }
     }
 
-    if (showMarkActionsSheet && selectedMark != null) {
-        val mark = selectedMark
-        ModalBottomSheet(onDismissRequest = { showMarkActionsSheet = false }) {
-            Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("${mark.type.label} mark", style = MaterialTheme.typography.titleMedium)
-                OutlinedButton(
-                    onClick = {
-                        activeTool = mark.type
-                        showMarkOptions = true
-                        showMarkActionsSheet = false
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Filled.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Text("Edit")
-                    }
-                }
-                TextButton(
-                    onClick = {
-                        marks.removeIf { it.id == mark.id }
-                        selectedMarkId = null
-                        activeTool = null
-                        showMarkActionsSheet = false
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Text("Delete")
-                    }
-                }
-            }
-        }
-    }
-
     Page(
         title = "Fill & Mark Document",
         back = back,
@@ -754,6 +716,25 @@ private fun FillMarkEditorScreen(
                     .padding(bottom = 4.dp),
                 verticalArrangement = Arrangement.spacedBy(6.dp),
             ) {
+                // Edit/Delete for the selected mark -- placed directly under the document,
+                // above the tool selector row, so it sits right next to what it acts on.
+                if (selectedMark != null) {
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(onClick = { activeTool = selectedMark.type; showMarkOptions = true }, modifier = Modifier.weight(1f)) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                                Icon(Icons.Filled.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
+                                Text("Edit")
+                            }
+                        }
+                        TextButton(onClick = { marks.removeIf { it.id == selectedMarkId }; selectedMarkId = null; activeTool = null }, modifier = Modifier.weight(1f)) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                                Text("Delete")
+                            }
+                        }
+                    }
+                }
+
                 // PDF page navigation
                 if (isPdf && pageCount > 0) {
                     Row(
@@ -841,29 +822,6 @@ private fun FillMarkEditorScreen(
                         color = MaterialTheme.colorScheme.primary,
                     )
                 }
-                // Fixed slot (not conditional on selection) so selecting/deselecting a mark
-                // doesn't shift this toolbar's height -- only enabled once something is
-                // selected. Opens a small actions sheet instead of inline Edit/Delete buttons,
-                // matching the same tap-for-actions pattern already used for saved
-                // signatures/stamps elsewhere in the app.
-                if (marks.isNotEmpty()) {
-                    Row(
-                        Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            selectedMark?.let { "Selected: ${it.type.label}" } ?: "Tap a mark to select it",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = if (selectedMark != null) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f),
-                        )
-                        IconButton(onClick = { showMarkActionsSheet = true }, enabled = selectedMark != null) {
-                            Icon(Icons.Filled.MoreVert, contentDescription = "Mark actions")
-                        }
-                    }
-                }
-
                 HorizontalDivider()
             }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -352,7 +352,6 @@ private fun FillMarkEditorScreen(
         ?: vm.signatures.firstOrNull { it.imageFileName != null }?.name
     var configSignatureName by remember { mutableStateOf<String?>(defaultSignatureName) }
     var configApplyToAll by remember { mutableStateOf(false) }
-    var showTextEntry by remember { mutableStateOf(false) }
 
     val textColors = remember {
         listOf(
@@ -536,25 +535,6 @@ private fun FillMarkEditorScreen(
                 status = "Export failed."
             }
         }
-    }
-
-    if (showTextEntry) {
-        val textFieldFocusRequester = remember { FocusRequester() }
-        ModalBottomSheet(onDismissRequest = { showTextEntry = false; activeTool = null }) {
-            Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                OutlinedTextField(
-                    value = configText,
-                    onValueChange = { configText = it },
-                    modifier = Modifier.fillMaxWidth().focusRequester(textFieldFocusRequester),
-                    placeholder = { Text("Type text") },
-                    singleLine = true,
-                )
-                Button(onClick = { showTextEntry = false }, modifier = Modifier.fillMaxWidth()) { Text("Place on document") }
-            }
-        }
-        // Open the sheet with the keyboard already up so the user can start typing
-        // immediately instead of having to tap the field first.
-        LaunchedEffect(Unit) { textFieldFocusRequester.requestFocus() }
     }
 
     if (showMarkOptions && activeTool != null) {
@@ -801,15 +781,16 @@ private fun FillMarkEditorScreen(
                         OutlinedButton(onClick = {
                             activeTool = null
                             selectedMarkId = null
-                            showTextEntry = false
                         }) { MarkToolContent("Text", Icons.Filled.TextFields) }
                     } else {
+                        // Same full config panel (color/size/font) as every other tool below,
+                        // instead of the old bare text-only sheet, so styling is available
+                        // right away instead of only after the mark is placed and re-edited.
                         TextButton(onClick = {
                             configText = ""
                             selectedMarkId = null
-                            showMarkOptions = false
                             activeTool = MarkType.Text
-                            showTextEntry = true
+                            showMarkOptions = true
                         }) { MarkToolContent("Text", Icons.Filled.TextFields) }
                     }
                     availableTools.filter { it != MarkType.Text }.forEach { tool ->
@@ -940,13 +921,19 @@ private fun MarkConfigPanel(
     ) {
         when (tool) {
             MarkType.Text -> {
+                val textFieldFocusRequester = remember { FocusRequester() }
                 OutlinedTextField(
                     value = configText,
                     onValueChange = onConfigTextChange,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().focusRequester(textFieldFocusRequester),
                     label = { Text("Text") },
                     singleLine = true,
                 )
+                if (selectedMark == null) {
+                    // Open with the keyboard already up when placing a new text mark, so the
+                    // user can start typing immediately instead of having to tap the field first.
+                    LaunchedEffect(Unit) { textFieldFocusRequester.requestFocus() }
+                }
                 TextMarkStyleControls(
                     configColorIdx, onColorChange, textColors,
                     configFontIdx, onFontChange, fontOptions,

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -1151,11 +1151,13 @@ private fun FontRow(fontIdx: Int, onFontChange: (Int) -> Unit, fontOptions: List
         } else {
             OutlinedButton(onClick = { onFontChange(-1) }) { Text(defaultLabel) }
         }
-        fontOptions.forEachIndexed { idx, (name, _) ->
+        fontOptions.forEachIndexed { idx, (name, typeface) ->
+            // Same as the fonts list screen: show each name set in its own actual typeface,
+            // not the default UI font, so you can see what you're picking.
             if (idx == fontIdx) {
-                Button(onClick = {}) { Text(name, maxLines = 1) }
+                Button(onClick = {}) { Text(name, maxLines = 1, fontFamily = FontFamily(typeface)) }
             } else {
-                OutlinedButton(onClick = { onFontChange(idx) }) { Text(name, maxLines = 1) }
+                OutlinedButton(onClick = { onFontChange(idx) }) { Text(name, maxLines = 1, fontFamily = FontFamily(typeface)) }
             }
         }
     }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -950,7 +950,10 @@ private fun TextMarkOverlay(
     BasicTextField(
         value = text,
         onValueChange = onTextChange,
-        singleLine = true,
+        // Multi-line so Enter inserts a newline instead of doing nothing, and long text wraps
+        // within the widthIn(max) below instead of running off the document -- matching how
+        // textMarkLayout now wraps/draws the same mark once it's no longer being edited.
+        singleLine = false,
         textStyle = TextStyle(
             color = ComposeColor(color),
             fontSize = with(density) { textSizePx.toSp() },
@@ -1266,39 +1269,49 @@ private fun markContainsPoint(
     val left = mark.offsetX * w
     val top = mark.offsetY * h
     val markWidth = mark.sizeFraction * w
-    // Text/Date's hit width must match how far the string actually renders (drawMarkOnCanvas
-    // draws it unclamped) -- markWidth alone is just a font-size estimate, so a longer string
-    // like "one two three" would render well past it, leaving its tail end untappable.
-    val width = when (mark.type) {
-        MarkType.Text, MarkType.Date ->
-            maxOf(markWidth, measuredTextMarkWidth(mark.text, markWidth, mark.fontKey, fontOptions))
-        MarkType.Check, MarkType.Signature, MarkType.Stamp -> markWidth
-    }
-    val height = when (mark.type) {
-        MarkType.Text, MarkType.Date, MarkType.Check -> markWidth * 0.5f
-        MarkType.Signature, MarkType.Stamp -> markWidth * 0.7f
+    // Text/Date's hit box must match how the string actually renders -- it now wraps at the
+    // document's right edge (drawMarkOnCanvas), so both its width (the widest wrapped line) and
+    // its height (grows with the number of lines) come from that same wrapped layout instead of
+    // a single-line estimate that would miss everything past the first line.
+    val (width, height) = when (mark.type) {
+        MarkType.Text, MarkType.Date -> {
+            val typeface = mark.fontKey?.let { key -> fontOptions.firstOrNull { it.first == key }?.second }
+            val layout = textMarkLayout(mark.text, markWidth * 0.25f, typeface, mark.colorArgb, w - left)
+            val lineWidth = (0 until layout.lineCount).maxOfOrNull { layout.getLineWidth(it) } ?: 0f
+            maxOf(markWidth, lineWidth) to maxOf(markWidth * 0.5f, layout.height.toFloat())
+        }
+        MarkType.Check -> markWidth to markWidth * 0.5f
+        MarkType.Signature, MarkType.Stamp -> markWidth to markWidth * 0.7f
     }
     return point.x in left..(left + width) && point.y in top..(top + height)
 }
 
-/** Actual rendered width (px) of a Text/Date mark's string, using the same font size and
- *  typeface drawMarkOnCanvas draws it with -- kept as one shared calculation so hit-testing
- *  and the selection highlight can't drift out of sync with each other or with the real
- *  drawn text again. */
-private fun measuredTextMarkWidth(
+/**
+ * Builds a wrapped, multi-line-aware layout for a Text/Date mark's string, breaking lines at
+ * [maxWidthPx] (the space remaining to the document's right edge) and at any newline the user
+ * typed on the document itself -- so long text, or text with explicit line breaks, flows onto
+ * more lines instead of running off the page. Shared by drawing (preview canvas + export
+ * bitmap/PDF) and hit-testing/selection sizing so all three always agree on where the text ends
+ * up.
+ */
+private fun textMarkLayout(
     text: String,
-    markWidth: Float,
-    fontKey: String?,
-    fontOptions: List<Pair<String, Typeface>>,
-): Float {
-    val textSizePx = markWidth * 0.25f
-    val paint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+    textSizePx: Float,
+    typeface: Typeface?,
+    colorArgb: Int,
+    maxWidthPx: Float,
+): android.text.StaticLayout {
+    val paint = android.text.TextPaint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+        color = colorArgb
         textSize = textSizePx.coerceAtLeast(8f)
-        if (fontKey != null) {
-            fontOptions.firstOrNull { it.first == fontKey }?.second?.let { typeface = it }
-        }
+        if (typeface != null) this.typeface = typeface
     }
-    return paint.measureText(text)
+    val width = maxWidthPx.coerceAtLeast(textSizePx * 4f).roundToInt().coerceAtLeast(1)
+    return android.text.StaticLayout.Builder
+        .obtain(text, 0, text.length, paint, width)
+        .setAlignment(android.text.Layout.Alignment.ALIGN_NORMAL)
+        .setIncludePad(false)
+        .build()
 }
 
 /**
@@ -1320,21 +1333,21 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawMarkOnCanvas(
 
     when (mark.type) {
         MarkType.Text, MarkType.Date -> {
-            val displayText = mark.text
-            val textSizePx = markWidth * 0.25f
+            val typeface = mark.fontKey?.let { key -> fontOptions.firstOrNull { it.first == key }?.second }
+            val layout = textMarkLayout(mark.text, markWidth * 0.25f, typeface, mark.colorArgb, w - left)
             drawIntoCanvas { c ->
-                val paint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
-                    color = mark.colorArgb
-                    textSize = textSizePx.coerceAtLeast(8f)
-                    if (mark.fontKey != null) {
-                        fontOptions.firstOrNull { it.first == mark.fontKey }?.second?.let { typeface = it }
-                    }
-                }
-                c.nativeCanvas.drawText(displayText, left, top + textSizePx, paint)
+                c.nativeCanvas.save()
+                c.nativeCanvas.translate(left, top)
+                layout.draw(c.nativeCanvas)
+                c.nativeCanvas.restore()
             }
             if (isSelected) {
-                val textW = measuredTextMarkWidth(displayText, markWidth, mark.fontKey, fontOptions)
-                drawSelectionRect(left, top, textW.coerceAtLeast(markWidth * 0.3f), markWidth * 0.3f)
+                val lineWidth = (0 until layout.lineCount).maxOfOrNull { layout.getLineWidth(it) } ?: 0f
+                drawSelectionRect(
+                    left, top,
+                    maxOf(markWidth * 0.3f, lineWidth),
+                    maxOf(markWidth * 0.3f, layout.height.toFloat()),
+                )
             }
         }
         MarkType.Check -> {
@@ -1536,14 +1549,12 @@ private fun drawMarkOnBitmap(
 
     when (mark.type) {
         MarkType.Text, MarkType.Date -> {
-            val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                color = mark.colorArgb
-                textSize = (markWidthPx * 0.25f).coerceAtLeast(8f)
-                if (mark.fontKey != null) {
-                    fontOptions.firstOrNull { it.first == mark.fontKey }?.second?.let { typeface = it }
-                }
-            }
-            canvas.drawText(mark.text, left, top + paint.textSize, paint)
+            val typeface = mark.fontKey?.let { key -> fontOptions.firstOrNull { it.first == key }?.second }
+            val layout = textMarkLayout(mark.text, markWidthPx * 0.25f, typeface, mark.colorArgb, pageWidth - left)
+            canvas.save()
+            canvas.translate(left, top)
+            layout.draw(canvas)
+            canvas.restore()
         }
         MarkType.Check -> {
             val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -626,8 +626,12 @@ private fun FillMarkEditorScreen(
         },
     ) {
         // The outer Column does NOT scroll — only the document area and the config panel
-        // (each independently) do.
-        Column(Modifier.fillMaxSize()) {
+        // (each independently) do. Deliberately NOT fillMaxSize(): the document and config
+        // panel below both shrink to their own content (weight(fill = false)), and forcing
+        // this Column to the full available height left the leftover space as a blank gap
+        // between the config panel and the pinned bottomBar. Sizing to actual content instead
+        // means the column ends exactly where its content ends.
+        Column(Modifier.fillMaxWidth()) {
 
             // ── DOCUMENT WORKSPACE ───────────────────────────────────────────── ─────────────────────────────────────────
             Box(
@@ -781,10 +785,6 @@ private fun FillMarkEditorScreen(
                         .padding(vertical = 6.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    Text(
-                        if (selectedMark == null) "Add ${configuringTool.label}" else "Edit ${configuringTool.label}",
-                        style = MaterialTheme.typography.titleMedium,
-                    )
                     MarkConfigPanel(
                         tool = configuringTool,
                         configColorIdx = configColorIdx,
@@ -828,12 +828,6 @@ private fun FillMarkEditorScreen(
                                 Text("Delete mark")
                             }
                         }
-                    } else {
-                        Text(
-                            "Tap the document to place ${configuringTool.label.lowercase()}.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
                     }
                 }
             }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -704,9 +704,17 @@ private fun FillMarkEditorScreen(
                                         val down = awaitFirstDown()
                                         val w = canvasDisplaySize.width.toFloat().coerceAtLeast(1f)
                                         val h = canvasDisplaySize.height.toFloat().coerceAtLeast(1f)
-                                        val hitMark = visibleMarks.lastOrNull { mark ->
-                                            markContainsPoint(mark, down.position, w, h)
-                                        }
+                                        // Re-read marks fresh here rather than closing over the
+                                        // outer visibleMarks val: this gesture handler's coroutine
+                                        // stays alive across many taps/drags whenever activeTool
+                                        // and currentPage don't change, so a val captured from the
+                                        // enclosing composable would keep the positions as they
+                                        // were the moment this handler last (re)started -- stale
+                                        // after any drag, making the old position still "hit"
+                                        // instead of where the mark visually moved to.
+                                        val hitMark = marks
+                                            .filter { it.applyToAllPages || it.targetPage == currentPage }
+                                            .lastOrNull { mark -> markContainsPoint(mark, down.position, w, h) }
                                         when {
                                             hitMark != null -> {
                                                 selectedMarkId = hitMark.id

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -41,6 +41,10 @@ import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Draw
+import androidx.compose.material.icons.filled.FontDownload
+import androidx.compose.material.icons.filled.FormatSize
+import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -860,6 +864,9 @@ private fun FillMarkShareIcon() {
 // Mark configuration panel
 // ---------------------------------------------------------------------------
 
+/** Which single control's UI is currently expanded below the icon row. */
+private enum class MarkControl { Color, Font, Size, CheckStyle, Asset, ApplyToAll }
+
 @Composable
 private fun MarkConfigPanel(
     tool: MarkType,
@@ -883,6 +890,13 @@ private fun MarkConfigPanel(
     onApplyToAllChange: (Boolean) -> Unit,
     selectedMark: DocumentMark?,
 ) {
+    // Which control (if any) is expanded below the icon row -- only one at a time, so this
+    // panel stays compact instead of showing color+font+size+... all at once.
+    var expandedControl by remember(tool) { mutableStateOf<MarkControl?>(null) }
+    fun toggle(control: MarkControl) {
+        expandedControl = if (expandedControl == control) null else control
+    }
+
     Column(
         Modifier
             .fillMaxWidth()
@@ -890,6 +904,8 @@ private fun MarkConfigPanel(
             .padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
+        // Content that's always visible for this mark type, regardless of which control (if
+        // any) is expanded below.
         when (tool) {
             MarkType.Text -> {
                 val textFieldFocusRequester = remember { FocusRequester() }
@@ -905,78 +921,84 @@ private fun MarkConfigPanel(
                     // user can start typing immediately instead of having to tap the field first.
                     LaunchedEffect(Unit) { textFieldFocusRequester.requestFocus() }
                 }
-                TextMarkStyleControls(
-                    configColorIdx, onColorChange, textColors,
-                    configFontIdx, onFontChange, fontOptions,
-                    configSizeFraction, onSizeChange,
-                )
             }
             MarkType.Date -> {
                 val today = remember { SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).format(Date()) }
                 Text("Date: $today", style = MaterialTheme.typography.bodySmall)
-                TextMarkStyleControls(
-                    configColorIdx, onColorChange, textColors,
-                    configFontIdx, onFontChange, fontOptions,
-                    configSizeFraction, onSizeChange,
-                )
             }
-            MarkType.Check -> {
-                Text("Check style", style = MaterialTheme.typography.labelMedium)
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    CheckStyle.entries.forEach { style ->
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            RadioButton(
-                                selected = configCheckStyle == style,
-                                onClick = { onCheckStyleChange(style) },
-                            )
-                            Text("${style.symbol} ${style.name}", style = MaterialTheme.typography.bodyMedium)
-                        }
+            MarkType.Check, MarkType.Signature, MarkType.Stamp -> Unit
+        }
+
+        // Icon toolbar -- one icon per control; tapping one reveals just that control below,
+        // e.g. tapping the font icon shows the font list, instead of a fixed block of every
+        // control at once.
+        Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+            when (tool) {
+                MarkType.Text, MarkType.Date, MarkType.Check -> {
+                    if (tool == MarkType.Check) {
+                        ControlIconButton(Icons.Filled.Check, "Check style", expandedControl == MarkControl.CheckStyle) { toggle(MarkControl.CheckStyle) }
+                    }
+                    ControlIconButton(Icons.Filled.Palette, "Colour", expandedControl == MarkControl.Color) { toggle(MarkControl.Color) }
+                    if (tool != MarkType.Check) {
+                        // Check's symbol is drawn without a typeface, so a font control here
+                        // wouldn't actually change anything -- left out rather than shown inert.
+                        ControlIconButton(Icons.Filled.FontDownload, "Font", expandedControl == MarkControl.Font) { toggle(MarkControl.Font) }
+                    }
+                    ControlIconButton(Icons.Filled.FormatSize, "Size", expandedControl == MarkControl.Size) { toggle(MarkControl.Size) }
+                }
+                MarkType.Signature, MarkType.Stamp -> {
+                    val assetIcon = if (tool == MarkType.Signature) Icons.Filled.Draw else Icons.Filled.Approval
+                    val assetLabel = if (tool == MarkType.Signature) "Choose signature" else "Choose stamp"
+                    ControlIconButton(assetIcon, assetLabel, expandedControl == MarkControl.Asset) { toggle(MarkControl.Asset) }
+                    ControlIconButton(Icons.Filled.FormatSize, "Size", expandedControl == MarkControl.Size) { toggle(MarkControl.Size) }
+                    if (isPdf) {
+                        ControlIconButton(Icons.Filled.Layers, "Apply to all pages", expandedControl == MarkControl.ApplyToAll) { toggle(MarkControl.ApplyToAll) }
                     }
                 }
-                TextMarkStyleControls(
-                    configColorIdx, onColorChange, textColors,
-                    configFontIdx, onFontChange, fontOptions,
-                    configSizeFraction, onSizeChange,
-                )
             }
-            MarkType.Signature -> {
-                val sigs = vm.signatures.filter { it.imageFileName == null }
+        }
+
+        // The single expanded control's own UI.
+        when (expandedControl) {
+            MarkControl.Color -> ColorRow(configColorIdx, onColorChange, textColors)
+            MarkControl.Font -> FontRow(configFontIdx, onFontChange, fontOptions)
+            MarkControl.Size -> SizeControl(configSizeFraction, onSizeChange)
+            MarkControl.CheckStyle -> CheckStyleRow(configCheckStyle, onCheckStyleChange)
+            MarkControl.Asset -> {
+                val items = if (tool == MarkType.Signature) {
+                    vm.signatures.filter { it.imageFileName == null }
+                } else {
+                    vm.signatures.filter { it.imageFileName != null }
+                }
                 SignatureStampSelector(
-                    label = "Select a signature",
-                    items = sigs,
+                    label = if (tool == MarkType.Signature) "Select a signature" else "Select a stamp",
+                    items = items,
                     selectedName = configSignatureName,
                     onSelect = onSignatureChange,
                 )
-                SizeControl(configSizeFraction, onSizeChange)
-                if (isPdf) ApplyToAllToggle(configApplyToAll, onApplyToAllChange)
             }
-            MarkType.Stamp -> {
-                val stamps = vm.signatures.filter { it.imageFileName != null }
-                SignatureStampSelector(
-                    label = "Select a stamp",
-                    items = stamps,
-                    selectedName = configSignatureName,
-                    onSelect = onSignatureChange,
-                )
-                SizeControl(configSizeFraction, onSizeChange)
-                if (isPdf) ApplyToAllToggle(configApplyToAll, onApplyToAllChange)
-            }
+            MarkControl.ApplyToAll -> ApplyToAllToggle(configApplyToAll, onApplyToAllChange)
+            null -> Unit
         }
     }
 }
 
+/** Icon button for one control in [MarkConfigPanel]'s toolbar; tinted primary while its own
+ *  section is the one expanded below. */
 @Composable
-private fun TextMarkStyleControls(
-    colorIdx: Int, onColorChange: (Int) -> Unit, colors: List<Pair<String, Int>>,
-    fontIdx: Int, onFontChange: (Int) -> Unit, fontOptions: List<Pair<String, Typeface>>,
-    sizeFraction: Float, onSizeChange: (Float) -> Unit,
-) {
+private fun ControlIconButton(icon: androidx.compose.ui.graphics.vector.ImageVector, label: String, selected: Boolean, onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        Icon(icon, contentDescription = label, tint = if (selected) MaterialTheme.colorScheme.primary else LocalContentColor.current)
+    }
+}
+
+@Composable
+private fun ColorRow(colorIdx: Int, onColorChange: (Int) -> Unit, colors: List<Pair<String, Int>>) {
     Row(
         Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text("Colour", style = MaterialTheme.typography.labelMedium)
         colors.forEachIndexed { idx, (_, argb) ->
             Box(
                 Modifier
@@ -991,29 +1013,46 @@ private fun TextMarkStyleControls(
             )
         }
     }
-    if (fontOptions.isNotEmpty()) {
-        Row(
-            Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState()),
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            val defaultLabel = "Default"
-            if (fontIdx < 0) {
-                Button(onClick = {}) { Text(defaultLabel) }
+}
+
+@Composable
+private fun FontRow(fontIdx: Int, onFontChange: (Int) -> Unit, fontOptions: List<Pair<String, Typeface>>) {
+    if (fontOptions.isEmpty()) return
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        val defaultLabel = "Default"
+        if (fontIdx < 0) {
+            Button(onClick = {}) { Text(defaultLabel) }
+        } else {
+            OutlinedButton(onClick = { onFontChange(-1) }) { Text(defaultLabel) }
+        }
+        fontOptions.forEachIndexed { idx, (name, _) ->
+            if (idx == fontIdx) {
+                Button(onClick = {}) { Text(name, maxLines = 1) }
             } else {
-                OutlinedButton(onClick = { onFontChange(-1) }) { Text(defaultLabel) }
-            }
-            fontOptions.forEachIndexed { idx, (name, _) ->
-                if (idx == fontIdx) {
-                    Button(onClick = {}) { Text(name, maxLines = 1) }
-                } else {
-                    OutlinedButton(onClick = { onFontChange(idx) }) { Text(name, maxLines = 1) }
-                }
+                OutlinedButton(onClick = { onFontChange(idx) }) { Text(name, maxLines = 1) }
             }
         }
     }
-    SizeControl(sizeFraction, onSizeChange)
+}
+
+@Composable
+private fun CheckStyleRow(checkStyle: CheckStyle, onCheckStyleChange: (CheckStyle) -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        CheckStyle.entries.forEach { style ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                RadioButton(
+                    selected = checkStyle == style,
+                    onClick = { onCheckStyleChange(style) },
+                )
+                Text("${style.symbol} ${style.name}", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Draw
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -334,6 +335,7 @@ private fun FillMarkEditorScreen(
     var selectedMarkId by remember { mutableStateOf<Long?>(null) }
     var activeTool by remember { mutableStateOf<MarkType?>(null) }
     var showMarkOptions by remember { mutableStateOf(false) }
+    var showMarkActionsSheet by remember { mutableStateOf(false) }
 
     // Per-tool config state (shared across marks for ergonomics)
     var configText by remember { mutableStateOf(initialText ?: "") }
@@ -613,6 +615,42 @@ private fun FillMarkEditorScreen(
         }
     }
 
+    if (showMarkActionsSheet && selectedMark != null) {
+        val mark = selectedMark
+        ModalBottomSheet(onDismissRequest = { showMarkActionsSheet = false }) {
+            Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("${mark.type.label} mark", style = MaterialTheme.typography.titleMedium)
+                OutlinedButton(
+                    onClick = {
+                        activeTool = mark.type
+                        showMarkOptions = true
+                        showMarkActionsSheet = false
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Filled.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Text("Edit")
+                    }
+                }
+                TextButton(
+                    onClick = {
+                        marks.removeIf { it.id == mark.id }
+                        selectedMarkId = null
+                        activeTool = null
+                        showMarkActionsSheet = false
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Text("Delete")
+                    }
+                }
+            }
+        }
+    }
+
     Page(
         title = "Fill & Mark Document",
         back = back,
@@ -803,19 +841,25 @@ private fun FillMarkEditorScreen(
                         color = MaterialTheme.colorScheme.primary,
                     )
                 }
-                if (selectedMark != null) {
-                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        OutlinedButton(onClick = { activeTool = selectedMark.type; showMarkOptions = true }, modifier = Modifier.weight(1f)) {
-                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
-                                Icon(Icons.Filled.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
-                                Text("Edit")
-                            }
-                        }
-                        TextButton(onClick = { marks.removeIf { it.id == selectedMarkId }; selectedMarkId = null; activeTool = null }, modifier = Modifier.weight(1f)) {
-                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
-                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
-                                Text("Delete")
-                            }
+                // Fixed slot (not conditional on selection) so selecting/deselecting a mark
+                // doesn't shift this toolbar's height -- only enabled once something is
+                // selected. Opens a small actions sheet instead of inline Edit/Delete buttons,
+                // matching the same tap-for-actions pattern already used for saved
+                // signatures/stamps elsewhere in the app.
+                if (marks.isNotEmpty()) {
+                    Row(
+                        Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            selectedMark?.let { "Selected: ${it.type.label}" } ?: "Tap a mark to select it",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (selectedMark != null) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f),
+                        )
+                        IconButton(onClick = { showMarkActionsSheet = true }, enabled = selectedMark != null) {
+                            Icon(Icons.Filled.MoreVert, contentDescription = "Mark actions")
                         }
                     }
                 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -348,6 +348,14 @@ private fun FillMarkEditorScreen(
     val marks = remember { mutableStateListOf<DocumentMark>() }
     var selectedMarkId by remember { mutableStateOf<Long?>(null) }
     var activeTool by remember { mutableStateOf<MarkType?>(null) }
+    // Which text mark (if any) currently has its on-document text field open for editing.
+    // Distinct from selectedMarkId: a single tap selects a mark (shows the config panel)
+    // without opening this; only a fresh placement or a double-tap opens it.
+    var editingTextMarkId by remember { mutableStateOf<Long?>(null) }
+    // Tracks the last plain tap on a text mark so a second tap shortly after, on the same
+    // mark, can be recognized as a double-tap rather than two independent single taps.
+    var lastTextTapMarkId by remember { mutableStateOf<Long?>(null) }
+    var lastTextTapTimeMs by remember { mutableStateOf(0L) }
 
     // Per-tool config state (shared across marks for ergonomics)
     var configText by remember { mutableStateOf(initialText ?: "") }
@@ -466,9 +474,9 @@ private fun FillMarkEditorScreen(
             offsetY = offsetY,
             sizeFraction = configSizeFraction,
             text = when (tool) {
-                // Starts empty -- the on-canvas overlay opens focused right after placement,
-                // ready for the user to type into, like a fresh input field.
-                MarkType.Text -> configText
+                // Text is placed via placeTextMarkAtCenter() below, straight from the
+                // toolbar -- it never goes through this tap-to-place path.
+                MarkType.Text -> error("Text is placed via placeTextMarkAtCenter")
                 MarkType.Date -> todayText
                 MarkType.Check -> ""
                 MarkType.Signature, MarkType.Stamp -> ""
@@ -488,6 +496,28 @@ private fun FillMarkEditorScreen(
         }
         selectedMarkId = newMark.id
         activeTool = null
+    }
+
+    // Tapping the Text tool places a mark immediately at the center of the document and opens
+    // its on-document text field there -- no separate canvas tap to choose a spot, matching
+    // "Use font on image"'s direct-entry experience.
+    fun placeTextMarkAtCenter() {
+        val width = configSizeFraction
+        val height = width * 0.5f
+        val newMark = DocumentMark(
+            type = MarkType.Text,
+            offsetX = ((1f - width) / 2f).coerceIn(0f, 0.85f),
+            offsetY = ((1f - height) / 2f).coerceIn(0f, 0.85f),
+            sizeFraction = configSizeFraction,
+            text = "",
+            colorArgb = textColors.getOrNull(configColorIdx)?.second ?: Color.BLACK,
+            fontKey = fontOptions.getOrNull(configFontIdx)?.first,
+            applyToAllPages = configApplyToAll,
+            targetPage = currentPage,
+        )
+        marks.add(newMark)
+        selectedMarkId = newMark.id
+        editingTextMarkId = newMark.id
     }
 
     fun updateSelectedMark() {
@@ -581,19 +611,14 @@ private fun FillMarkEditorScreen(
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
-                    val isTextMode = activeTool == MarkType.Text
-                    if (isTextMode) {
-                        OutlinedButton(onClick = {
-                            activeTool = null
-                            selectedMarkId = null
-                        }) { MarkToolContent("Text", Icons.Filled.TextFields) }
-                    } else {
-                        TextButton(onClick = {
-                            configText = ""
-                            selectedMarkId = null
-                            activeTool = MarkType.Text
-                        }) { MarkToolContent("Text", Icons.Filled.TextFields) }
-                    }
+                    // Text acts immediately -- unlike the other tools, there's no "armed" state
+                    // to tap the canvas into. Each tap places a fresh mark at the center of the
+                    // document and opens its text field right there.
+                    TextButton(onClick = {
+                        activeTool = null
+                        configText = ""
+                        placeTextMarkAtCenter()
+                    }) { MarkToolContent("Text", Icons.Filled.TextFields) }
                     availableTools.filter { it != MarkType.Text }.forEach { tool ->
                         val compactLabel = when (tool) {
                             MarkType.Date -> "Date"
@@ -611,7 +636,7 @@ private fun FillMarkEditorScreen(
                         }
                         val isActive = activeTool == tool
                         if (isActive) {
-                            OutlinedButton(onClick = { activeTool = null; selectedMarkId = null }) { MarkToolContent(compactLabel, icon) }
+                            OutlinedButton(onClick = { activeTool = null; selectedMarkId = null; editingTextMarkId = null }) { MarkToolContent(compactLabel, icon) }
                         } else {
                             TextButton(onClick = {
                                 activeTool = tool
@@ -621,6 +646,7 @@ private fun FillMarkEditorScreen(
                                     else -> configSignatureName
                                 }
                                 selectedMarkId = null
+                                editingTextMarkId = null
                             }) { MarkToolContent(compactLabel, icon) }
                         }
                     }
@@ -680,6 +706,7 @@ private fun FillMarkEditorScreen(
                                         when {
                                             hitMark != null -> {
                                                 selectedMarkId = hitMark.id
+                                                var moved = false
                                                 drag(down.id) { change ->
                                                     // positionChange() returns Offset.Zero once the
                                                     // change is consumed, so it must be read before
@@ -688,6 +715,7 @@ private fun FillMarkEditorScreen(
                                                     // every drag delta and made dragging a no-op.
                                                     val delta = change.positionChange()
                                                     change.consume()
+                                                    if (delta != Offset.Zero) moved = true
                                                     val idx = marks.indexOfFirst { it.id == hitMark.id }
                                                     if (idx >= 0) {
                                                         val m = marks[idx]
@@ -696,6 +724,25 @@ private fun FillMarkEditorScreen(
                                                             offsetY = (m.offsetY + delta.y / h).coerceIn(0f, 1f),
                                                         )
                                                     }
+                                                }
+                                                // A plain tap (no movement) on a text mark either
+                                                // opens it for editing (double-tap) or just selects
+                                                // it to show the config panel (single tap) -- a drag
+                                                // does neither, it only repositions the mark above.
+                                                if (!moved && hitMark.type == MarkType.Text) {
+                                                    val now = System.currentTimeMillis()
+                                                    val isDoubleTap = hitMark.id == lastTextTapMarkId &&
+                                                        (now - lastTextTapTimeMs) < 300L
+                                                    if (isDoubleTap) {
+                                                        editingTextMarkId = hitMark.id
+                                                        lastTextTapMarkId = null
+                                                    } else {
+                                                        editingTextMarkId = null
+                                                        lastTextTapMarkId = hitMark.id
+                                                        lastTextTapTimeMs = now
+                                                    }
+                                                } else {
+                                                    lastTextTapMarkId = null
                                                 }
                                             }
                                             activeTool != null -> {
@@ -706,7 +753,10 @@ private fun FillMarkEditorScreen(
                                                 }
                                             }
                                             else -> {
-                                                if (waitForUpOrCancellation() != null) selectedMarkId = null
+                                                if (waitForUpOrCancellation() != null) {
+                                                    selectedMarkId = null
+                                                    editingTextMarkId = null
+                                                }
                                             }
                                         }
                                     }
@@ -717,18 +767,21 @@ private fun FillMarkEditorScreen(
                             visibleMarks.forEach { mark ->
                                 // The actively-edited text mark is skipped here -- the overlay
                                 // below renders its live text directly instead, so drawing it
-                                // here too would just double it up underneath the overlay.
-                                if (mark.type == MarkType.Text && mark.id == selectedMarkId) return@forEach
+                                // here too would just double it up underneath the overlay. A
+                                // merely-selected (not editing) text mark is still drawn normally.
+                                if (mark.type == MarkType.Text && mark.id == editingTextMarkId) return@forEach
                                 val isSelected = mark.id == selectedMarkId
                                 drawMarkOnCanvas(mark, w, h, isSelected, fontOptions, sigBitmapCache)
                             }
                         }
                         // Text is typed directly on the document, right where it will appear --
                         // matching "Use font on image" -- instead of in a separate field in the
-                        // config panel below.
-                        if (selectedMark != null && selectedMark.type == MarkType.Text && canvasDisplaySize.width > 0) {
+                        // config panel below. Only shown right after placement or a double-tap
+                        // (editingTextMarkId), not on every plain selection.
+                        val editingMark = selectedMark?.takeIf { it.id == editingTextMarkId }
+                        if (editingMark != null && editingMark.type == MarkType.Text && canvasDisplaySize.width > 0) {
                             TextMarkOverlay(
-                                mark = selectedMark,
+                                mark = editingMark,
                                 canvasSize = canvasDisplaySize,
                                 text = configText,
                                 onTextChange = { configText = it; updateSelectedMark() },
@@ -822,6 +875,7 @@ private fun FillMarkEditorScreen(
                             marks.removeIf { it.id == selectedMarkId }
                             selectedMarkId = null
                             activeTool = null
+                            editingTextMarkId = null
                         }) {
                             Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
                                 Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -348,9 +348,16 @@ fun FontCreatorApp(
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
-@Composable internal fun Page(title: String, back: (() -> Unit)? = null, scrollable: Boolean = false, actions: @Composable RowScope.() -> Unit = {}, content: @Composable ColumnScope.() -> Unit) {
+@Composable internal fun Page(
+    title: String,
+    back: (() -> Unit)? = null,
+    scrollable: Boolean = false,
+    actions: @Composable RowScope.() -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    content: @Composable ColumnScope.() -> Unit,
+) {
     BackHandler(enabled = back != null) { back?.invoke() }
-    Scaffold(topBar = { AppTopBar(title, back, actions) }) { padding ->
+    Scaffold(topBar = { AppTopBar(title, back, actions) }, bottomBar = bottomBar) { padding ->
         val scrollModifier = if (scrollable) Modifier.verticalScroll(rememberScrollState()) else Modifier
         Column(
             Modifier.fillMaxSize().padding(padding).padding(16.dp).then(scrollModifier),

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -354,13 +354,19 @@ fun FontCreatorApp(
     scrollable: Boolean = false,
     actions: @Composable RowScope.() -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
+    // Every other screen wants its content column stretched to the full available height
+    // (e.g. so a list inside it fills the screen) -- opt out only when the content itself
+    // manages its own sizing and a forced-full-height column would just leave blank space
+    // below it, above a pinned bottomBar.
+    fillAvailableHeight: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     BackHandler(enabled = back != null) { back?.invoke() }
     Scaffold(topBar = { AppTopBar(title, back, actions) }, bottomBar = bottomBar) { padding ->
         val scrollModifier = if (scrollable) Modifier.verticalScroll(rememberScrollState()) else Modifier
+        val sizeModifier = if (fillAvailableHeight) Modifier.fillMaxSize() else Modifier.fillMaxWidth()
         Column(
-            Modifier.fillMaxSize().padding(padding).padding(16.dp).then(scrollModifier),
+            sizeModifier.padding(padding).padding(16.dp).then(scrollModifier),
             verticalArrangement = Arrangement.spacedBy(12.dp),
             content = content,
         )

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -291,12 +291,6 @@ fun FontCreatorApp(
                     previewText = previewText,
                     changePreviewText = { value -> previewText = value; preferences.edit().putString("preview_text", value).apply() },
                     back = { screen = Screen.Letters },
-                    startDrawing = {
-                        viewModel.disablePhraseMode()
-                        screen = Screen.Letters
-                        val nextMissing = viewModel.activeCharacterOrder.firstOrNull { it !in viewModel.drawings }
-                        if (nextMissing != null) viewModel.edit(nextMissing) else viewModel.editLetters()
-                    },
                     useOnImage = { fontName, text ->
                         preferredImageFontName = fontName
                         initialImageText = text

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -17,6 +17,8 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.concurrent.Executors
 
@@ -366,6 +368,22 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
             file to loadTypeface(file)
         }.onSuccess { (file, typeface) -> main.post { generatedFont = file; previewTypeface = typeface; status = "${snapshot.name} generated and saved." } }
             .onFailure { error -> main.post { status = "Could not generate font: ${error.message ?: "unknown error"}" } } }
+    }
+
+    /** Loads [project]'s generated Typeface for lightweight previews (e.g. the fonts list),
+     *  off the main thread -- the *real* font, not an approximation, so it matches Fine-tune's
+     *  rendering exactly. Reuses the same generated file [generate] would produce if one
+     *  already exists on disk, otherwise builds and persists it there now, so a later visit to
+     *  Fine-tune or Use-on-image finds it ready instead of regenerating it again. */
+    suspend fun typefaceForPreview(project: FontProject): Typeface? = withContext(Dispatchers.IO) {
+        runCatching {
+            val file = generatedFile(project.name)
+            if (!file.exists()) {
+                if (project.drawings.isEmpty()) return@withContext null
+                file.writeBytes(TrueTypeGenerator().generate(project.drawings, project.wordSpacingMm, project.letterSpacingMm, project.name))
+            }
+            loadTypeface(file)
+        }.getOrNull()
     }
 
     fun importFont(contentResolver: ContentResolver, uri: Uri, displayName: String) {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -100,7 +100,11 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     fun allFontOptions(): List<Pair<String, Typeface>> {
         val app = getApplication<Application>()
         val generated = projects.mapNotNull { project ->
-            if (project.drawings.isEmpty()) return@mapNotNull null
+            // An incomplete font is missing glyphs for some of its own selected characters --
+            // offering it here would let it be picked to write arbitrary text that then renders
+            // with gaps for whatever hasn't been drawn yet. The fonts library screen still shows
+            // it (with its "x of y" progress), just not as a usable font elsewhere until done.
+            if (!isProjectComplete(project)) return@mapNotNull null
             val file = generatedFile(project.name)
             runCatching {
                 // Keep Library fonts usable and current even if the user has not opened Preview.

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontDrawingScreens.kt
@@ -600,8 +600,10 @@ internal fun SpacingControl(
     }
 }
 
+/** Renders one drawn letter scaled to fit `modifier`'s bounds. Also reused by
+ *  FontsModuleScreen.kt as a font-list row thumbnail. */
 @Composable
-private fun GlyphBarPreview(drawing: GlyphDrawing, color: Color, modifier: Modifier = Modifier) {
+internal fun GlyphBarPreview(drawing: GlyphDrawing, color: Color, modifier: Modifier = Modifier) {
     Canvas(modifier) {
         val scale = minOf(
             size.width / drawing.canvasWidth.coerceAtLeast(1f),

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Undo
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -44,7 +45,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -58,7 +59,6 @@ import com.jaafar.remoteconfig.R
     previewText: String,
     changePreviewText: (String) -> Unit,
     back: () -> Unit,
-    startDrawing: () -> Unit,
     useOnImage: (String, String) -> Unit,
 ) {
     val project = vm.activeProject
@@ -66,10 +66,6 @@ import com.jaafar.remoteconfig.R
         Page("Fine-tune your font", back) { Text("Choose a handwriting font first.") }
         return
     }
-    val requiredCharacters = vm.activeCharacterOrder.toSet()
-    val drawnCodePoints = project.drawings.map { it.codePoint }.toSet()
-    val drawn = drawnCodePoints.intersect(requiredCharacters).size
-    val complete = requiredCharacters.isNotEmpty() && requiredCharacters.all { it in drawnCodePoints }
     var letterSpacing by remember(project.name) { mutableFloatStateOf(project.letterSpacingMm) }
     var wordSpacing by remember(project.name) { mutableFloatStateOf(project.wordSpacingMm) }
     val updateSpacing: (Float, Float) -> Unit = { nextLetter, nextWord ->
@@ -78,77 +74,96 @@ import com.jaafar.remoteconfig.R
         if (vm.setSpacing(nextLetter.toString(), nextWord.toString())) vm.generate()
     }
 
+    // Matches the iOS app's "Fine-tune your font" screen: the preview *is* the screen --
+    // a big live-rendered card with the text field woven directly into it, a single
+    // slider-based spacing card, and one primary action -- instead of a status banner,
+    // a completion badge, +/- spacing steppers, and two competing buttons.
     Page("Fine-tune your font", back, scrollable = true) {
         Surface(
             modifier = Modifier.fillMaxWidth(),
-            color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = .72f),
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .6f),
             shape = RoundedCornerShape(24.dp),
         ) {
             Column(
                 Modifier.fillMaxWidth().padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(7.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                Text(
-                    if (complete) "FINAL STEP" else "PREVIEW",
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                Text(project.name, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
-                Text(
-                    if (complete) "Your alphabet is complete. Give the font its finishing touch."
-                    else "Preview the letters you have drawn and keep building when you are ready.",
-                    style = MaterialTheme.typography.bodyMedium,
+                Box(Modifier.fillMaxWidth().heightIn(min = 130.dp), contentAlignment = Alignment.Center) {
+                    val typeface = vm.previewTypeface
+                    if (typeface == null) {
+                        CircularProgressIndicator()
+                    } else {
+                        Text(
+                            previewText.ifBlank { " " },
+                            style = MaterialTheme.typography.headlineMedium.copy(fontFamily = FontFamily(typeface)),
+                            textAlign = TextAlign.Center,
+                            maxLines = 4,
+                        )
+                    }
+                }
+                OutlinedTextField(
+                    value = previewText,
+                    onValueChange = changePreviewText,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text("Type something to preview") },
+                    textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.Center),
                 )
             }
         }
-        if (vm.previewTypeface == null) {
-            Text("Creating your font…", color = MaterialTheme.colorScheme.onSurfaceVariant)
-            LinearProgressIndicator(Modifier.fillMaxWidth())
-            Text("Turning $drawn drawn letters into a usable font preview.", style = MaterialTheme.typography.bodySmall)
-        } else {
+        if (vm.previewTypeface != null) {
             Surface(
-                color = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                shape = RoundedCornerShape(12.dp),
-            ) {
-                Text(
-                    if (complete) "FONT FILE READY" else "$drawn LETTERS INCLUDED",
-                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
-            Text(
-                if (complete) "Try a real phrase below, then adjust the rhythm until it feels like your handwriting."
-                else "Preview and adjust the letters you have drawn so far.",
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            OutlinedTextField(
-                value = previewText,
-                onValueChange = changePreviewText,
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("Preview text") },
-                minLines = 3,
-                textStyle = MaterialTheme.typography.headlineMedium.copy(fontFamily = FontFamily(vm.previewTypeface!!)),
-            )
-            Text("Spacing", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            SpacingControl(label = "Letter spacing", value = letterSpacing, step = 0.25f, min = -3f, max = 10f) {
-                updateSpacing(it, wordSpacing)
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .3f),
+                shape = RoundedCornerShape(16.dp),
+            ) {
+                Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    // These ranges match what TrueTypeGenerator actually produces (its hmtx
+                    // advance widths are clamped to 500..4096 / 100..4096 font units) --
+                    // the previous wider ranges mostly got silently clamped to the same
+                    // value, so dragging looked like it did something but had no effect.
+                    SpacingSlider("Letter spacing", letterSpacing, -3f..4f, 0.25f) { updateSpacing(it, wordSpacing) }
+                    SpacingSlider("Word spacing", wordSpacing, 0.25f..8f, 0.25f) { updateSpacing(letterSpacing, it) }
+                    Text(
+                        "Changes save automatically.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
-            SpacingControl(label = "Word spacing", value = wordSpacing, step = 0.5f, min = 0.2f, max = 50f) {
-                updateSpacing(letterSpacing, it)
-            }
-            Text("Spacing changes are saved automatically.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             Button(onClick = { useOnImage(project.name, previewText) }, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Filled.Image, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
                 Text("Use on an image")
-            }
-            OutlinedButton(onClick = startDrawing, modifier = Modifier.fillMaxWidth()) {
-                Text("Continue full alphabet")
             }
         }
         if (vm.status.isNotBlank()) Text(vm.status, style = MaterialTheme.typography.bodySmall)
+    }
+}
+
+@Composable
+private fun SpacingSlider(
+    label: String,
+    value: Float,
+    range: ClosedFloatingPointRange<Float>,
+    step: Float,
+    onChange: (Float) -> Unit,
+) {
+    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(label, style = MaterialTheme.typography.titleMedium)
+            Text(
+                "${String.format(java.util.Locale.US, "%.2f", value)} mm",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Slider(
+            value = value,
+            onValueChange = onChange,
+            valueRange = range,
+            steps = ((range.endInclusive - range.start) / step).toInt() - 1,
+        )
     }
 }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
@@ -157,9 +157,11 @@ import com.jaafar.remoteconfig.R
     IconButton(onClick = { val uri = FileProvider.getUriForFile(context, "${context.packageName}.files", file); context.startActivity(Intent.createChooser(Intent(Intent.ACTION_SEND).apply { type = "font/ttf"; putExtra(Intent.EXTRA_STREAM, uri); addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION) }, "Share $name")) }) { ActionIcon(ActionIconType.Share, "Share $name") }
 }
 
-private enum class ActionIconType { Add, Edit, Share, Import }
+internal enum class ActionIconType { Add, Edit, Share, Import }
 
-@Composable private fun ActionIcon(type: ActionIconType, description: String) {
+/** Hand-drawn action glyph (this app's own icon set, not Material Icons) -- reused wherever
+ *  an add/edit/share/import action needs an icon-only control instead of a text button. */
+@Composable internal fun ActionIcon(type: ActionIconType, description: String) {
     val color = LocalContentColor.current
     Canvas(Modifier.size(24.dp).semantics { contentDescription = description }) {
         val stroke = 2.dp.toPx()

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
@@ -42,6 +42,7 @@ internal fun FontsModuleScreen(
     var importName by remember { mutableStateOf("") }
     var projectToDelete by remember { mutableStateOf<FontProject?>(null) }
     var importedToDelete by remember { mutableStateOf<ImportedFont?>(null) }
+    var showAddMenu by remember { mutableStateOf(false) }
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri != null) {
             val raw = context.contentResolver.query(uri, arrayOf(android.provider.OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
@@ -53,14 +54,23 @@ internal fun FontsModuleScreen(
         }
     }
 
-    Page("Fonts", back) {
-        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = createFont, modifier = Modifier.weight(1f)) { Text("Create font") }
-            OutlinedButton(
-                onClick = { picker.launch(arrayOf("font/ttf", "font/otf", "application/octet-stream", "*/*")) },
-                modifier = Modifier.weight(1f),
-            ) { Text("Import font") }
-        }
+    Page(
+        "Fonts",
+        back,
+        actions = {
+            IconButton(onClick = { showAddMenu = true }) { ActionIcon(ActionIconType.Add, "Add font") }
+            DropdownMenu(expanded = showAddMenu, onDismissRequest = { showAddMenu = false }) {
+                DropdownMenuItem(text = { Text("Draw new font") }, onClick = { showAddMenu = false; createFont() })
+                DropdownMenuItem(
+                    text = { Text("Import font file") },
+                    onClick = {
+                        showAddMenu = false
+                        picker.launch(arrayOf("font/ttf", "font/otf", "application/octet-stream", "*/*"))
+                    },
+                )
+            }
+        },
+    ) {
         if (vm.projects.isEmpty() && vm.importedFonts.isEmpty()) {
             Column(
                 Modifier.fillMaxWidth().padding(vertical = 32.dp),
@@ -75,7 +85,7 @@ internal fun FontsModuleScreen(
                 )
                 Text("No fonts yet", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
                 Text(
-                    "Create your handwriting font or import a font you own.",
+                    "Tap + to draw your handwriting font or import one you own.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
@@ -26,8 +25,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /** Matches iOS's "Complete" green -- Material has no built-in success color. */
 private val CompleteGreen = Color(0xFF2E7D32)
@@ -101,42 +100,31 @@ internal fun FontsModuleScreen(
                         val complete = vm.isProjectComplete(project)
                         val total = vm.characterCount(project).coerceAtLeast(1)
                         val drawn = project.drawings.size.coerceAtMost(total)
-                        val byCode = remember(project.drawings) {
-                            project.drawings.filter { it.strokes.isNotEmpty() }.associateBy { it.codePoint }
+                        // The *real* generated font, loaded off the main thread -- the same one
+                        // Fine-tune shows -- so the name and thumbnail here match that screen
+                        // exactly instead of approximating it from raw pen strokes.
+                        val previewTypeface by produceState<android.graphics.Typeface?>(null, project.name, project.drawings, complete) {
+                            value = if (complete) vm.typefaceForPreview(project) else null
                         }
-                        // Only spell the name out in the user's own handwriting once the font is
-                        // complete AND every character the name actually needs has been drawn --
-                        // otherwise fall back to the system font like any other row.
-                        val canSpellName = complete && project.name.any { !it.isWhitespace() } &&
-                            project.name.all { it.isWhitespace() || byCode.containsKey(it.code) }
                         OutlinedCard(Modifier.fillMaxWidth().clickable { openProject(vm.projects.indexOf(project)) }) {
                             Row(
                                 Modifier.fillMaxWidth().padding(12.dp),
                                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                AaThumbnail(byCode)
+                                AaThumbnail(previewTypeface)
                                 Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                     Row(
                                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                                         verticalAlignment = Alignment.CenterVertically,
                                     ) {
-                                        if (canSpellName) {
-                                            HandwrittenText(
-                                                project.name,
-                                                byCode,
-                                                MaterialTheme.colorScheme.onSurface,
-                                                glyphSize = 24.dp,
-                                                modifier = Modifier.weight(1f, fill = false),
-                                            )
-                                        } else {
-                                            Text(
-                                                project.name,
-                                                style = MaterialTheme.typography.titleMedium,
-                                                fontWeight = FontWeight.Bold,
-                                                modifier = Modifier.weight(1f, fill = false),
-                                            )
-                                        }
+                                        Text(
+                                            project.name,
+                                            style = MaterialTheme.typography.titleMedium,
+                                            fontWeight = FontWeight.Bold,
+                                            fontFamily = previewTypeface?.let { androidx.compose.ui.text.font.FontFamily(it) },
+                                            modifier = Modifier.weight(1f, fill = false),
+                                        )
                                         FontStatusBadge(if (complete) "Complete" else "$drawn of $total", showCheck = complete)
                                     }
                                     Text(
@@ -251,42 +239,25 @@ private fun FontThumbnail(
     }
 }
 
-/** 56dp rounded thumbnail for a drawn font: "Aa" in the user's own handwriting once both
- *  letters are drawn, else an edit icon prompting them to keep drawing. */
+/** 56dp rounded thumbnail for a drawn font: "Aa" rendered in the font itself once it's
+ *  generated, else an edit icon prompting them to keep drawing. */
 @Composable
-private fun AaThumbnail(byCode: Map<Int, GlyphDrawing>) {
-    val upperA = byCode['A'.code]
-    val lowerA = byCode['a'.code]
+private fun AaThumbnail(typeface: android.graphics.Typeface?) {
     Box(
         Modifier
             .size(56.dp)
             .background(MaterialTheme.colorScheme.primaryContainer, RoundedCornerShape(14.dp)),
         contentAlignment = Alignment.Center,
     ) {
-        if (upperA != null && lowerA != null) {
-            Row(horizontalArrangement = Arrangement.spacedBy(2.dp), verticalAlignment = Alignment.CenterVertically) {
-                GlyphBarPreview(upperA, MaterialTheme.colorScheme.primary, Modifier.size(24.dp))
-                GlyphBarPreview(lowerA, MaterialTheme.colorScheme.primary, Modifier.size(24.dp))
-            }
+        if (typeface != null) {
+            Text(
+                "Aa",
+                fontFamily = androidx.compose.ui.text.font.FontFamily(typeface),
+                fontSize = 24.sp,
+                color = MaterialTheme.colorScheme.primary,
+            )
         } else {
             Icon(Icons.Filled.Edit, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-        }
-    }
-}
-
-/** Spells out [text] using the user's own hand-drawn letter strokes instead of a system
- *  font -- shown for a font's name once every character it needs has actually been drawn. */
-@Composable
-private fun HandwrittenText(text: String, byCode: Map<Int, GlyphDrawing>, color: Color, glyphSize: Dp, modifier: Modifier = Modifier) {
-    Row(modifier.clipToBounds(), verticalAlignment = Alignment.CenterVertically) {
-        text.forEach { ch ->
-            if (ch.isWhitespace()) {
-                Spacer(Modifier.width(glyphSize * .4f))
-            } else {
-                byCode[ch.code]?.let { drawing ->
-                    GlyphBarPreview(drawing, color, Modifier.size(glyphSize))
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
@@ -25,6 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /** Matches iOS's "Complete" green -- Material has no built-in success color. */
@@ -99,25 +101,42 @@ internal fun FontsModuleScreen(
                         val complete = vm.isProjectComplete(project)
                         val total = vm.characterCount(project).coerceAtLeast(1)
                         val drawn = project.drawings.size.coerceAtMost(total)
-                        val thumbnail = project.drawings.filter { it.strokes.isNotEmpty() }.minByOrNull { it.codePoint }
+                        val byCode = remember(project.drawings) {
+                            project.drawings.filter { it.strokes.isNotEmpty() }.associateBy { it.codePoint }
+                        }
+                        // Only spell the name out in the user's own handwriting once the font is
+                        // complete AND every character the name actually needs has been drawn --
+                        // otherwise fall back to the system font like any other row.
+                        val canSpellName = complete && project.name.any { !it.isWhitespace() } &&
+                            project.name.all { it.isWhitespace() || byCode.containsKey(it.code) }
                         OutlinedCard(Modifier.fillMaxWidth().clickable { openProject(vm.projects.indexOf(project)) }) {
                             Row(
                                 Modifier.fillMaxWidth().padding(12.dp),
                                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                FontThumbnail(thumbnail, placeholderIcon = Icons.Filled.Edit)
+                                AaThumbnail(byCode)
                                 Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                     Row(
                                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                                         verticalAlignment = Alignment.CenterVertically,
                                     ) {
-                                        Text(
-                                            project.name,
-                                            style = MaterialTheme.typography.titleMedium,
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.weight(1f, fill = false),
-                                        )
+                                        if (canSpellName) {
+                                            HandwrittenText(
+                                                project.name,
+                                                byCode,
+                                                MaterialTheme.colorScheme.onSurface,
+                                                glyphSize = 24.dp,
+                                                modifier = Modifier.weight(1f, fill = false),
+                                            )
+                                        } else {
+                                            Text(
+                                                project.name,
+                                                style = MaterialTheme.typography.titleMedium,
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.weight(1f, fill = false),
+                                            )
+                                        }
                                         FontStatusBadge(if (complete) "Complete" else "$drawn of $total", showCheck = complete)
                                     }
                                     Text(
@@ -228,6 +247,46 @@ private fun FontThumbnail(
             GlyphBarPreview(drawing, MaterialTheme.colorScheme.primary, Modifier.fillMaxSize().padding(10.dp))
         } else {
             Icon(placeholderIcon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        }
+    }
+}
+
+/** 56dp rounded thumbnail for a drawn font: "Aa" in the user's own handwriting once both
+ *  letters are drawn, else an edit icon prompting them to keep drawing. */
+@Composable
+private fun AaThumbnail(byCode: Map<Int, GlyphDrawing>) {
+    val upperA = byCode['A'.code]
+    val lowerA = byCode['a'.code]
+    Box(
+        Modifier
+            .size(56.dp)
+            .background(MaterialTheme.colorScheme.primaryContainer, RoundedCornerShape(14.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (upperA != null && lowerA != null) {
+            Row(horizontalArrangement = Arrangement.spacedBy(2.dp), verticalAlignment = Alignment.CenterVertically) {
+                GlyphBarPreview(upperA, MaterialTheme.colorScheme.primary, Modifier.size(24.dp))
+                GlyphBarPreview(lowerA, MaterialTheme.colorScheme.primary, Modifier.size(24.dp))
+            }
+        } else {
+            Icon(Icons.Filled.Edit, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        }
+    }
+}
+
+/** Spells out [text] using the user's own hand-drawn letter strokes instead of a system
+ *  font -- shown for a font's name once every character it needs has actually been drawn. */
+@Composable
+private fun HandwrittenText(text: String, byCode: Map<Int, GlyphDrawing>, color: Color, glyphSize: Dp, modifier: Modifier = Modifier) {
+    Row(modifier.clipToBounds(), verticalAlignment = Alignment.CenterVertically) {
+        text.forEach { ch ->
+            if (ch.isWhitespace()) {
+                Spacer(Modifier.width(glyphSize * .4f))
+            } else {
+                byCode[ch.code]?.let { drawing ->
+                    GlyphBarPreview(drawing, color, Modifier.size(glyphSize))
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontsModuleScreen.kt
@@ -3,19 +3,32 @@ package com.jaafar.remoteconfig.fontcreator
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+
+/** Matches iOS's "Complete" green -- Material has no built-in success color. */
+private val CompleteGreen = Color(0xFF2E7D32)
 
 @Composable
 internal fun FontsModuleScreen(
@@ -49,19 +62,68 @@ internal fun FontsModuleScreen(
             ) { Text("Import font") }
         }
         if (vm.projects.isEmpty() && vm.importedFonts.isEmpty()) {
-            Text("No fonts yet. Create your handwriting font or import a font you own.")
+            Column(
+                Modifier.fillMaxWidth().padding(vertical = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    Icons.Filled.TextFields,
+                    contentDescription = null,
+                    modifier = Modifier.size(40.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text("No fonts yet", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(
+                    "Create your handwriting font or import a font you own.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
         } else {
             LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 if (vm.projects.isNotEmpty()) {
                     item { Text("CREATED FONTS", style = MaterialTheme.typography.titleSmall) }
                     items(vm.projects, key = { it.name }) { project ->
+                        val complete = vm.isProjectComplete(project)
+                        val total = vm.characterCount(project).coerceAtLeast(1)
+                        val drawn = project.drawings.size.coerceAtMost(total)
+                        val thumbnail = project.drawings.filter { it.strokes.isNotEmpty() }.minByOrNull { it.codePoint }
                         OutlinedCard(Modifier.fillMaxWidth().clickable { openProject(vm.projects.indexOf(project)) }) {
-                            Row(Modifier.fillMaxWidth().padding(16.dp)) {
-                                Column(Modifier.weight(1f)) {
-                                    Text(project.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-                                    Text("${project.drawings.size} of ${vm.characterCount(project)} characters")
+                            Row(
+                                Modifier.fillMaxWidth().padding(12.dp),
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                FontThumbnail(thumbnail, placeholderIcon = Icons.Filled.Edit)
+                                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Text(
+                                            project.name,
+                                            style = MaterialTheme.typography.titleMedium,
+                                            fontWeight = FontWeight.Bold,
+                                            modifier = Modifier.weight(1f, fill = false),
+                                        )
+                                        FontStatusBadge(if (complete) "Complete" else "$drawn of $total", showCheck = complete)
+                                    }
+                                    Text(
+                                        "Created font",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                    LinearProgressIndicator(
+                                        progress = drawn.toFloat() / total,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        color = if (complete) CompleteGreen else MaterialTheme.colorScheme.primary,
+                                    )
                                 }
-                                TextButton(onClick = { projectToDelete = project }) { Text("Delete") }
+                                IconButton(onClick = { projectToDelete = project }) {
+                                    Icon(Icons.Filled.Delete, contentDescription = "Delete ${project.name}")
+                                }
                             }
                         }
                     }
@@ -70,9 +132,34 @@ internal fun FontsModuleScreen(
                     item { Text("IMPORTED FONTS", style = MaterialTheme.typography.titleSmall) }
                     items(vm.importedFonts, key = { it.fileName }) { font ->
                         OutlinedCard(Modifier.fillMaxWidth()) {
-                            Row(Modifier.fillMaxWidth().padding(16.dp)) {
-                                Text(font.displayName, modifier = Modifier.weight(1f), style = MaterialTheme.typography.titleMedium)
-                                TextButton(onClick = { importedToDelete = font }) { Text("Delete") }
+                            Row(
+                                Modifier.fillMaxWidth().padding(12.dp),
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                FontThumbnail(drawing = null, placeholderIcon = Icons.Filled.TextFields)
+                                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Text(
+                                            font.displayName,
+                                            style = MaterialTheme.typography.titleMedium,
+                                            fontWeight = FontWeight.Bold,
+                                            modifier = Modifier.weight(1f, fill = false),
+                                        )
+                                        FontStatusBadge("Ready", showCheck = true)
+                                    }
+                                    Text(
+                                        "Imported font",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                IconButton(onClick = { importedToDelete = font }) {
+                                    Icon(Icons.Filled.Delete, contentDescription = "Delete ${font.displayName}")
+                                }
                             }
                         }
                     }
@@ -112,6 +199,42 @@ internal fun FontsModuleScreen(
             confirmButton = { TextButton(onClick = { vm.deleteImportedFont(font.fileName); importedToDelete = null }) { Text("Delete") } },
             dismissButton = { TextButton(onClick = { importedToDelete = null }) { Text("Cancel") } },
         )
+    }
+}
+
+/** 56dp rounded thumbnail: the given letter drawing if there is one, else a placeholder icon. */
+@Composable
+private fun FontThumbnail(
+    drawing: GlyphDrawing?,
+    placeholderIcon: androidx.compose.ui.graphics.vector.ImageVector,
+) {
+    Box(
+        Modifier
+            .size(56.dp)
+            .background(MaterialTheme.colorScheme.primaryContainer, RoundedCornerShape(14.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (drawing != null) {
+            GlyphBarPreview(drawing, MaterialTheme.colorScheme.primary, Modifier.fillMaxSize().padding(10.dp))
+        } else {
+            Icon(placeholderIcon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        }
+    }
+}
+
+/** Small colored capsule, e.g. "Complete" or "12 of 94". */
+@Composable
+private fun FontStatusBadge(text: String, showCheck: Boolean) {
+    val color = if (showCheck) CompleteGreen else MaterialTheme.colorScheme.primary
+    Row(
+        Modifier
+            .background(color.copy(alpha = 0.12f), RoundedCornerShape(50))
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (showCheck) Icon(Icons.Filled.Check, contentDescription = null, tint = color, modifier = Modifier.size(14.dp))
+        Text(text, style = MaterialTheme.typography.labelSmall, color = color, fontWeight = FontWeight.SemiBold)
     }
 }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -168,14 +169,16 @@ fun ImageTextEditorScreen(
                 if (isEditingText) {
                     TextButton(onClick = { isEditingText = false; keyboard?.hide() }) { Text("Done") }
                 } else {
-                    TextButton(
+                    // Icon-only, matching ShareButton's use elsewhere in the app (the font
+                    // workspace's own share action) instead of a text label here.
+                    IconButton(
                         enabled = bitmap != null && text.isNotBlank(),
                         onClick = {
                             bitmap?.let { source ->
                                 shareImage(context, renderImage(source, text, typeface, sizePercent, textColor.value, textPosition))
                             }
                         },
-                    ) { Text("Share") }
+                    ) { ActionIcon(ActionIconType.Share, "Share image") }
                 }
             }
         },

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -128,7 +128,7 @@ fun ImageTextEditorScreen(
     var textPosition by remember { mutableStateOf(Offset(.5f, .85f)) }
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
     var activePanel by remember { mutableStateOf<EditorPanel?>(null) }
-    var isEditingText by remember { mutableStateOf(false) }
+    var isEditingText by remember(imageUri, initialText) { mutableStateOf(initialText.isBlank()) }
     var fontQuery by remember { mutableStateOf("") }
     var showAllFonts by remember { mutableStateOf(false) }
     var fontFilter by remember { mutableStateOf(FontFilter.All) }
@@ -237,15 +237,21 @@ fun ImageTextEditorScreen(
                         val left = ((size.width - width) / 2f).roundToInt()
                         val top = ((size.height - height) / 2f).roundToInt()
                         drawImage(bitmap.asImageBitmap(), dstOffset = IntOffset(left, top), dstSize = IntSize(width, height))
-                        if (!isEditingText) {
-                            drawIntoCanvas { canvas ->
-                                val paint = overlayPaint(typeface, height * sizePercent / 100f, textColor.value)
-                                drawOverlayText(
-                                    canvas.nativeCanvas, text,
-                                    left + width * textPosition.x, top + height * textPosition.y,
-                                    width * .9f, paint,
-                                )
-                            }
+                        // Always draw the same Paint-based wrapped text that renderImage() uses for
+                        // the exported file, during editing too -- this is the single source of
+                        // truth for how the text wraps. The BasicTextField below (shown only while
+                        // editing) renders its own text invisibly and exists purely to host the
+                        // cursor and keyboard input: letting Compose's own soft-wrap draw the
+                        // *visible* glyphs there could disagree with this Paint-based wrap for the
+                        // app's custom-generated fonts, which is what made lengthy text collapse
+                        // onto a single line as soon as editing ended.
+                        drawIntoCanvas { canvas ->
+                            val paint = overlayPaint(typeface, height * sizePercent / 100f, textColor.value)
+                            drawOverlayText(
+                                canvas.nativeCanvas, text,
+                                left + width * textPosition.x, top + height * textPosition.y,
+                                width * .9f, paint,
+                            )
                         }
                     }
                     if (isEditingText && canvasSize.width > 0 && canvasSize.height > 0) {
@@ -271,13 +277,16 @@ fun ImageTextEditorScreen(
                                 .background(MaterialTheme.colorScheme.surface.copy(alpha = .35f))
                                 .padding(6.dp)
                                 .focusRequester(textFocusRequester),
+                            // Text itself is invisible -- the Canvas above already draws the real,
+                            // correctly-wrapped text -- so only the cursor is visible here.
                             textStyle = MaterialTheme.typography.bodyLarge.copy(
-                                color = textColor.composeColor,
+                                color = Color.Transparent,
                                 fontFamily = androidx.compose.ui.text.font.FontFamily(typeface),
                                 fontSize = editorTextSize,
                                 lineHeight = editorLineHeight,
                                 textAlign = TextAlign.Center,
                             ),
+                            cursorBrush = androidx.compose.ui.graphics.SolidColor(textColor.composeColor),
                         )
                     }
                 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignaturesModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignaturesModuleScreen.kt
@@ -17,9 +17,12 @@ internal fun SignaturesModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, 
         return
     }
     val signatures = vm.signatures.filter { it.imageFileName == null }
-    Page("Signatures", back) {
-        Button(onClick = { creating = true }, modifier = Modifier.fillMaxWidth()) { Text("Create signature") }
-        if (signatures.isEmpty()) Text("No signatures yet. Draw one once and reuse it whenever you sign a document.")
+    Page(
+        "Signatures",
+        back,
+        actions = { IconButton(onClick = { creating = true }) { ActionIcon(ActionIconType.Add, "Create signature") } },
+    ) {
+        if (signatures.isEmpty()) Text("No signatures yet. Tap + to draw one and reuse it whenever you sign a document.")
         else LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             items(signatures, key = { it.name }) { signature ->
                 SavedMarkCard(signature, vm.defaultSignatureName == signature.name) { selected = signature }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignaturesModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignaturesModuleScreen.kt
@@ -3,9 +3,14 @@ package com.jaafar.remoteconfig.fontcreator
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Draw
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -20,12 +25,36 @@ internal fun SignaturesModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, 
     Page(
         "Signatures",
         back,
-        actions = { IconButton(onClick = { creating = true }) { ActionIcon(ActionIconType.Add, "Create signature") } },
+        // Matches iOS's rule: the "+" only shows once there's something to add to -- an
+        // empty list already has its own prominent action below, so showing both would be
+        // a redundant second way to do the same thing.
+        actions = {
+            if (signatures.isNotEmpty()) {
+                IconButton(onClick = { creating = true }) { ActionIcon(ActionIconType.Add, "Create signature") }
+            }
+        },
     ) {
-        if (signatures.isEmpty()) Text("No signatures yet. Tap + to draw one and reuse it whenever you sign a document.")
-        else LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            items(signatures, key = { it.name }) { signature ->
-                SavedMarkCard(signature, vm.defaultSignatureName == signature.name) { selected = signature }
+        if (signatures.isEmpty()) {
+            Column(
+                Modifier.fillMaxWidth().weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+            ) {
+                Icon(Icons.Filled.Draw, contentDescription = null, modifier = Modifier.size(40.dp), tint = MaterialTheme.colorScheme.primary)
+                Text("No signatures yet", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(
+                    "Draw one once and reuse it whenever you sign a document.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+                Button(onClick = { creating = true }) { Text("Create signature") }
+            }
+        } else {
+            LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                items(signatures, key = { it.name }) { signature ->
+                    SavedMarkCard(signature, vm.defaultSignatureName == signature.name) { selected = signature }
+                }
             }
         }
     }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/StampsModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/StampsModuleScreen.kt
@@ -17,9 +17,12 @@ internal fun StampsModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, useI
         return
     }
     val stamps = vm.signatures.filter { it.imageFileName != null }
-    Page("Stamps", back) {
-        Button(onClick = { importing = true }, modifier = Modifier.fillMaxWidth()) { Text("Add stamp") }
-        if (stamps.isEmpty()) Text("No stamps yet. Import an image once and reuse it on documents.")
+    Page(
+        "Stamps",
+        back,
+        actions = { IconButton(onClick = { importing = true }) { ActionIcon(ActionIconType.Add, "Add stamp") } },
+    ) {
+        if (stamps.isEmpty()) Text("No stamps yet. Tap + to import an image and reuse it on documents.")
         else LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             items(stamps, key = { it.name }) { stamp ->
                 SavedMarkCard(stamp, vm.defaultStampName == stamp.name) { selected = stamp }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/StampsModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/StampsModuleScreen.kt
@@ -3,9 +3,14 @@ package com.jaafar.remoteconfig.fontcreator
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Approval
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -20,12 +25,36 @@ internal fun StampsModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, useI
     Page(
         "Stamps",
         back,
-        actions = { IconButton(onClick = { importing = true }) { ActionIcon(ActionIconType.Add, "Add stamp") } },
+        // Matches iOS's rule: the "+" only shows once there's something to add to -- an
+        // empty list already has its own prominent action below, so showing both would be
+        // a redundant second way to do the same thing.
+        actions = {
+            if (stamps.isNotEmpty()) {
+                IconButton(onClick = { importing = true }) { ActionIcon(ActionIconType.Add, "Add stamp") }
+            }
+        },
     ) {
-        if (stamps.isEmpty()) Text("No stamps yet. Tap + to import an image and reuse it on documents.")
-        else LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            items(stamps, key = { it.name }) { stamp ->
-                SavedMarkCard(stamp, vm.defaultStampName == stamp.name) { selected = stamp }
+        if (stamps.isEmpty()) {
+            Column(
+                Modifier.fillMaxWidth().weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+            ) {
+                Icon(Icons.Filled.Approval, contentDescription = null, modifier = Modifier.size(40.dp), tint = MaterialTheme.colorScheme.primary)
+                Text("No stamps yet", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(
+                    "Import an image once and reuse it on documents.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+                Button(onClick = { importing = true }) { Text("Add stamp") }
+            }
+        } else {
+            LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                items(stamps, key = { it.name }) { stamp ->
+                    SavedMarkCard(stamp, vm.defaultStampName == stamp.name) { selected = stamp }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

**1. Redesign the fonts list to match iOS's richer row style** (`FontsModuleScreen.kt`, `FontDrawingScreens.kt`)
- Thumbnail preview, completion badge ("Complete" / "X of Y"), progress bar, and icon-only delete per row, instead of a plain text list.
- Consolidated "Create font" / "Import font" into a single "+" menu.
- Empty state: icon + heading + short description instead of a bare message.

**2. Icon-only toolbar actions instead of text buttons** (Fonts, Signatures/Stamps "+", `ImageTextEditorScreen.kt` Share)
- Matches this app's own iOS convention (icon-first toolbar actions) — Jakob's Law: the same gesture should mean the same thing across screens users already know from the iOS app.

**3. Centered empty-state actions for Signatures/Stamps; icon-forward Fill & Mark controls**
- Restored iOS's actual dual-state rule: when the list is empty, show a centered icon + heading + description + primary button in the middle of the screen; once there's at least one item, switch to the top-right "+" icon only (no redundant second entry point).
- Fill & Mark's tool selector (Text/Date/Check/Sign/Stamp) is now icon + label instead of text-only chips.

**4. Fill & Mark: remove the duplicate Export & Share button**
- The bottom-of-screen full-width "Export & Share" button did exactly what the top app bar's share icon already did (with a looser enabled condition), so it was a second, redundant way to trigger the same export. Removed it and kept the top-bar icon as the single entry point.

**5. Fill & Mark: Edit/Delete row, document spacing, and tap-to-reselect**
- Edit/Delete for the selected mark is an inline row placed directly under the document, above the Text/Date/Check/Sign/Stamp tool selector.
- Fixed excess empty space between the document and the controls below it (the document area no longer force-fills all remaining screen space).
- Fixed tap-to-reselect an existing mark being unreliable: tap-select and drag-move were two independent, competing gesture detectors on the same canvas; merged them into a single gesture handler.
- The text-entry sheet now auto-focuses its field so the keyboard opens immediately when you tap the Text control.

**6. Redesigned "Fine-tune your font" to match iOS's simpler preview screen**
- Replaced the status banner, completion badge, +/- spacing steppers, and two competing buttons with: one card weaving the live preview and text input together, one card with slider-based spacing controls, and a single "Use on an image" action.
- Narrowed the spacing ranges to match what the font generator's advance-width clamping actually allows, since the old wider ranges mostly had no visible effect past a point (matching a fix already on iOS).

## Notes
- I could not run a full Gradle build here — this environment's network policy blocks `dl.google.com` (Android Gradle Plugin's Maven repo). I did careful manual review instead, following patterns already used and CI-validated elsewhere in this codebase. Please have CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz