### PR TITLE
Fill & Mark instant placement + Signatures/Stamps inline actions

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -51,6 +51,8 @@ import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.HorizontalDivider
@@ -358,6 +360,11 @@ private fun FillMarkEditorScreen(
     // mark, can be recognized as a double-tap rather than two independent single taps.
     var lastTextTapMarkId by remember { mutableStateOf<Long?>(null) }
     var lastTextTapTimeMs by remember { mutableStateOf(0L) }
+    // Which asset-picker dropdown (if any) is open, when Signature/Stamp has more than one
+    // saved asset to choose from -- picking there places the mark immediately, same as tapping
+    // Sign/Stamp does directly when there's only one.
+    var signaturePickerExpanded by remember { mutableStateOf(false) }
+    var stampPickerExpanded by remember { mutableStateOf(false) }
 
     // Per-tool config state (shared across marks for ergonomics)
     var configText by remember { mutableStateOf(initialText ?: "") }
@@ -505,6 +512,23 @@ private fun FillMarkEditorScreen(
         activeTool = null
     }
 
+    // Date, and Signature/Stamp once a specific asset is known (either the only one available,
+    // or one just picked from the toolbar's dropdown), place immediately at the center of the
+    // document -- same direct-entry spirit as Text, no separate canvas tap needed. Reuses
+    // addOrUpdateMark's mark-building logic by arming activeTool just for this one call.
+    fun placeMarkAtCenter(tool: MarkType, signatureName: String? = null) {
+        activeTool = tool
+        if (signatureName != null) configSignatureName = signatureName
+        val width = configSizeFraction
+        val height = when (tool) {
+            MarkType.Signature, MarkType.Stamp -> width * 0.7f
+            else -> width * 0.5f
+        }
+        val offsetX = ((1f - width) / 2f).coerceIn(0f, 0.85f)
+        val offsetY = ((1f - height) / 2f).coerceIn(0f, 0.85f)
+        addOrUpdateMark(offsetX, offsetY)
+    }
+
     // Tapping the Text tool places a mark immediately at the center of the document and opens
     // its on-document text field there -- no separate canvas tap to choose a spot, matching
     // "Use font on image"'s direct-entry experience.
@@ -641,20 +665,67 @@ private fun FillMarkEditorScreen(
                             MarkType.Stamp -> Icons.Filled.Approval
                             MarkType.Text -> error("Text is handled above")
                         }
-                        val isActive = activeTool == tool
-                        if (isActive) {
-                            OutlinedButton(onClick = { activeTool = null; selectedMarkId = null; editingTextMarkId = null }) { MarkToolContent(compactLabel, icon) }
-                        } else {
-                            TextButton(onClick = {
-                                activeTool = tool
-                                configSignatureName = when (tool) {
-                                    MarkType.Signature -> defaultSignatureName
-                                    MarkType.Stamp -> defaultStampName
-                                    else -> configSignatureName
+                        when (tool) {
+                            MarkType.Date -> {
+                                // Same direct-entry spirit as Text: no armed state, no canvas
+                                // tap -- it just appears at the center of the document.
+                                TextButton(onClick = {
+                                    selectedMarkId = null
+                                    editingTextMarkId = null
+                                    placeMarkAtCenter(MarkType.Date)
+                                }) { MarkToolContent(compactLabel, icon) }
+                            }
+                            MarkType.Signature, MarkType.Stamp -> {
+                                val isSignature = tool == MarkType.Signature
+                                val assetNames = vm.signatures
+                                    .filter { (it.imageFileName == null) == isSignature }
+                                    .map { it.name }
+                                Box {
+                                    TextButton(onClick = {
+                                        selectedMarkId = null
+                                        editingTextMarkId = null
+                                        if (assetNames.size <= 1) {
+                                            // Only one saved signature/stamp -- nothing to
+                                            // choose, so place it immediately, same as Date.
+                                            placeMarkAtCenter(tool, assetNames.firstOrNull())
+                                        } else if (isSignature) {
+                                            signaturePickerExpanded = true
+                                        } else {
+                                            stampPickerExpanded = true
+                                        }
+                                    }) { MarkToolContent(compactLabel, icon) }
+                                    val expanded = if (isSignature) signaturePickerExpanded else stampPickerExpanded
+                                    DropdownMenu(
+                                        expanded = expanded,
+                                        onDismissRequest = {
+                                            if (isSignature) signaturePickerExpanded = false else stampPickerExpanded = false
+                                        },
+                                    ) {
+                                        assetNames.forEach { name ->
+                                            DropdownMenuItem(
+                                                text = { Text(name) },
+                                                onClick = {
+                                                    if (isSignature) signaturePickerExpanded = false else stampPickerExpanded = false
+                                                    placeMarkAtCenter(tool, name)
+                                                },
+                                            )
+                                        }
+                                    }
                                 }
-                                selectedMarkId = null
-                                editingTextMarkId = null
-                            }) { MarkToolContent(compactLabel, icon) }
+                            }
+                            MarkType.Check -> {
+                                val isActive = activeTool == MarkType.Check
+                                if (isActive) {
+                                    OutlinedButton(onClick = { activeTool = null; selectedMarkId = null; editingTextMarkId = null }) { MarkToolContent(compactLabel, icon) }
+                                } else {
+                                    TextButton(onClick = {
+                                        activeTool = MarkType.Check
+                                        selectedMarkId = null
+                                        editingTextMarkId = null
+                                    }) { MarkToolContent(compactLabel, icon) }
+                                }
+                            }
+                            MarkType.Text -> error("Text is handled above")
                         }
                     }
                 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SavedMarkComponents.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SavedMarkComponents.kt
@@ -2,37 +2,24 @@ package com.jaafar.remoteconfig.fontcreator
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
+/**
+ * One saved signature/stamp row. Tapping the row itself goes straight to signing/stamping a
+ * document with it -- no intermediate "what do you want to do with this" dialog. Rename and
+ * delete are inline icons on the row instead, and there's no "make default" action: the last
+ * one actually used already becomes the default automatically (see FillMarkScreen's placement
+ * logic), so a manual toggle here was a redundant second way to set the same thing.
+ */
 @Composable
-internal fun SavedMarkCard(mark: SavedSignature, isDefault: Boolean, click: () -> Unit) {
-    OutlinedCard(Modifier.fillMaxWidth().clickable(onClick = click)) {
-        Row(
-            Modifier.fillMaxWidth().padding(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            SignaturePreview(Modifier.size(88.dp, 56.dp), mark)
-            Column {
-                Text(mark.name, style = MaterialTheme.typography.titleMedium)
-                if (isDefault) Text("Default", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-internal fun SavedMarkActionsSheet(
-    vm: FontCreatorViewModel,
-    mark: SavedSignature,
-    useInDocument: (String) -> Unit,
-    dismiss: () -> Unit,
-) {
+internal fun SavedMarkCard(vm: FontCreatorViewModel, mark: SavedSignature, useInDocument: (String) -> Unit) {
     var renaming by remember { mutableStateOf(false) }
     var name by remember(mark.name) { mutableStateOf(mark.name) }
     if (renaming) {
@@ -41,27 +28,27 @@ internal fun SavedMarkActionsSheet(
             title = { Text("Rename ${if (mark.imageFileName == null) "signature" else "stamp"}") },
             text = { OutlinedTextField(name, { name = it }, label = { Text("Name") }, singleLine = true) },
             confirmButton = {
-                Button(onClick = { if (vm.renameSignature(mark.name, name)) { renaming = false; dismiss() } }, enabled = name.isNotBlank()) {
+                Button(onClick = { if (vm.renameSignature(mark.name, name)) renaming = false }, enabled = name.isNotBlank()) {
                     Text("Rename")
                 }
             },
             dismissButton = { TextButton(onClick = { renaming = false }) { Text("Cancel") } },
         )
     }
-    ModalBottomSheet(onDismissRequest = dismiss) {
-        Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            SignaturePreview(Modifier.fillMaxWidth().height(130.dp), mark)
-            Text(mark.name, style = MaterialTheme.typography.titleMedium)
-            Button(onClick = { useInDocument(mark.name) }, modifier = Modifier.fillMaxWidth()) { Text("Use in a document") }
-            OutlinedButton(
-                onClick = {
-                    if (mark.imageFileName == null) vm.setDefaultSignature(mark.name) else vm.setDefaultStamp(mark.name)
-                    dismiss()
-                },
-                modifier = Modifier.fillMaxWidth(),
-            ) { Text("Make default") }
-            OutlinedButton(onClick = { renaming = true }, modifier = Modifier.fillMaxWidth()) { Text("Rename") }
-            TextButton(onClick = { vm.deleteSignature(mark.name); dismiss() }, modifier = Modifier.fillMaxWidth()) { Text("Delete") }
+    OutlinedCard(Modifier.fillMaxWidth().clickable { useInDocument(mark.name) }) {
+        Row(
+            Modifier.fillMaxWidth().padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SignaturePreview(Modifier.size(88.dp, 56.dp), mark)
+            Text(mark.name, style = MaterialTheme.typography.titleMedium, modifier = Modifier.weight(1f))
+            IconButton(onClick = { renaming = true }) {
+                Icon(Icons.Filled.Edit, contentDescription = "Rename ${mark.name}")
+            }
+            IconButton(onClick = { vm.deleteSignature(mark.name) }) {
+                Icon(Icons.Filled.Delete, contentDescription = "Delete ${mark.name}")
+            }
         }
     }
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignaturesModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignaturesModuleScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.unit.dp
 @Composable
 internal fun SignaturesModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, useInDocument: (String) -> Unit) {
     var creating by remember { mutableStateOf(false) }
-    var selected by remember { mutableStateOf<SavedSignature?>(null) }
     if (creating) {
         SignatureEditorScreen(vm = vm, onSaved = { creating = false }, back = { creating = false })
         return
@@ -53,10 +52,9 @@ internal fun SignaturesModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, 
         } else {
             LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(signatures, key = { it.name }) { signature ->
-                    SavedMarkCard(signature, vm.defaultSignatureName == signature.name) { selected = signature }
+                    SavedMarkCard(vm, signature, useInDocument)
                 }
             }
         }
     }
-    selected?.let { mark -> SavedMarkActionsSheet(vm, mark, useInDocument) { selected = null } }
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/StampsModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/StampsModuleScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.unit.dp
 @Composable
 internal fun StampsModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, useInDocument: (String) -> Unit) {
     var importing by remember { mutableStateOf(false) }
-    var selected by remember { mutableStateOf<SavedSignature?>(null) }
     if (importing) {
         ImportStampFromImageScreen(vm = vm, onSaved = { importing = false }, back = { importing = false })
         return
@@ -53,10 +52,9 @@ internal fun StampsModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, useI
         } else {
             LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(stamps, key = { it.name }) { stamp ->
-                    SavedMarkCard(stamp, vm.defaultStampName == stamp.name) { selected = stamp }
+                    SavedMarkCard(vm, stamp, useInDocument)
                 }
             }
         }
     }
-    selected?.let { mark -> SavedMarkActionsSheet(vm, mark, useInDocument) { selected = null } }
 }


### PR DESCRIPTION
## Summary

**1. Fill & Mark: Date/Signature/Stamp place instantly, like Text does**
- Date now places at the center of the document immediately on tap, same as Text — no more arming the tool and tapping the canvas separately.
- Signature and Stamp do the same when there's only one saved asset. With more than one, tapping Sign/Stamp opens a dropdown right from the toolbar button to pick which one, and picking it places the mark immediately — asset selection now happens from the toolbar instead of requiring you to place first and then find it in the config panel below.
- Check is unchanged (still armed, then tapped onto the canvas) — it has no asset to pick and wasn't part of this request.

**2. Signatures/Stamps: inline rename/delete, tap row to sign/stamp a document**
- Replaced the bottom-sheet-of-options a tap used to open with inline Edit/Delete icons directly on each row.
- Tapping the row itself now goes straight to signing/stamping a document with it (same destination the sheet's "Use in a document" button used to send you to), instead of requiring a dialog first.
- Dropped "Make default" — FillMarkScreen's placement logic already sets the default automatically from whichever one was actually used last, so the manual toggle was a redundant second way to set the same thing.
- Applies to both Signatures and Stamps, since both screens already shared this same row component.

## Notes
- I could not run a full Gradle build here — this environment's network policy blocks `dl.google.com` (Android Gradle Plugin's Maven repo). I did careful manual review instead, following patterns already used and CI-validated elsewhere in this codebase. Please have CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz