### PR TITLE
Signature edit flow + Fill & Mark auto-placement, font defaults, Fine-tune fixes

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -329,8 +329,10 @@ private fun FillMarkEditorScreen(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    // completeOnly = true: arbitrary typed text here could hit a glyph an in-progress font
+    // hasn't drawn yet, unlike "Use font on image" which only ever writes a fixed phrase.
     val fontOptions = remember(vm.projects.toList(), vm.importedFonts.toList(), vm.generatedFont) {
-        vm.allFontOptions()
+        vm.allFontOptions(completeOnly = true)
     }
 
     // Document state
@@ -362,7 +364,11 @@ private fun FillMarkEditorScreen(
     // Per-tool config state (shared across marks for ergonomics)
     var configText by remember { mutableStateOf(initialText ?: "") }
     var configColorIdx by remember { mutableIntStateOf(0) }
-    var configFontIdx by remember { mutableIntStateOf(-1) }
+    // Defaults to the user's own most recently modified font (fontOptions is already sorted
+    // that way) instead of the generic system font, so a fresh Text/Date mark reads in their
+    // own handwriting from the start -- falls back to -1 (system Default) only when they have
+    // no usable font yet.
+    var configFontIdx by remember { mutableIntStateOf(if (fontOptions.isNotEmpty()) 0 else -1) }
     var configSizeFraction by remember { mutableFloatStateOf(0.20f) }
     var configCheckStyle by remember { mutableStateOf(CheckStyle.Check) }
     val defaultSignatureName = vm.signatures.firstOrNull { it.imageFileName == null && it.name == vm.defaultSignatureName }?.name
@@ -563,7 +569,7 @@ private fun FillMarkEditorScreen(
 
     // Export action – captured in a lambda so the icon button in the top bar can trigger it.
     fun triggerExport() {
-        val fontOptionsSnapshot = vm.allFontOptions()
+        val fontOptionsSnapshot = vm.allFontOptions(completeOnly = true)
         val signaturesSnapshot = vm.signatures.toList()
         scope.launch {
             isProcessing = true

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -223,11 +223,16 @@ private fun canOpenRecentDoc(context: android.content.Context, uri: Uri): Boolea
  *
  * @param initialUri  URI passed in via the Android Share sheet (ACTION_SEND).
  *                    When non-null the editor opens immediately with this document.
+ * @param initialMarkName  A saved signature/stamp's name to place automatically once a
+ *                    document is loaded -- the entry point from Signatures/Stamps' own
+ *                    "use in a document" action: choose a document here first, then land in
+ *                    the editor with that mark already placed at the center.
  */
 @Composable
 internal fun FillMarkScreen(
     vm: FontCreatorViewModel,
     initialUri: Uri? = null,
+    initialMarkName: String? = null,
     back: () -> Unit,
 ) {
     var documentUri by remember { mutableStateOf(initialUri) }
@@ -247,6 +252,7 @@ internal fun FillMarkScreen(
         FillMarkEditorScreen(
             vm = vm,
             documentUri = documentUri!!,
+            initialMarkName = initialMarkName,
             back = { documentUri = null },
         )
     }
@@ -327,6 +333,7 @@ private fun FillMarkEditorScreen(
     vm: FontCreatorViewModel,
     documentUri: Uri,
     initialText: String? = null,
+    initialMarkName: String? = null,
     back: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -527,6 +534,17 @@ private fun FillMarkEditorScreen(
         val offsetX = ((1f - width) / 2f).coerceIn(0f, 0.85f)
         val offsetY = ((1f - height) / 2f).coerceIn(0f, 0.85f)
         addOrUpdateMark(offsetX, offsetY)
+    }
+
+    // Arriving here from Signatures/Stamps' "Use in Fill & Mark" action: place that saved
+    // mark at the center immediately, same as tapping its tool in the toolbar when there's
+    // only one to choose from -- initialMarkName doesn't change over this screen's lifetime,
+    // so this runs once.
+    LaunchedEffect(initialMarkName) {
+        val name = initialMarkName ?: return@LaunchedEffect
+        val asset = vm.signatures.firstOrNull { it.name == name } ?: return@LaunchedEffect
+        val tool = if (asset.imageFileName == null) MarkType.Signature else MarkType.Stamp
+        placeMarkAtCenter(tool, name)
     }
 
     // Tapping the Text tool places a mark immediately at the center of the document and opens

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -94,7 +94,7 @@ private val ModernDarkColors = darkColorScheme(
     outlineVariant = Color(0xFF45464F),
 )
 
-internal enum class Screen { Home, Fonts, Signatures, Stamps, FontCelebration, FontReady, Letters, Signature, FillMark, Settings }
+internal enum class Screen { Home, Fonts, Signatures, Stamps, FontCelebration, FontReady, Letters, FillMark, Settings }
 
 @Composable
 fun FontCreatorApp(
@@ -129,6 +129,10 @@ fun FontCreatorApp(
         sharedUri ?: return@LaunchedEffect
         showTutorial = false
         fillMarkUri = sharedUri
+        // A pending mark from an earlier "use in Fill & Mark" visit could otherwise still be
+        // set if that visit was backed out of internally (picker -> Home was never reached),
+        // which would auto-place it on this unrelated newly shared document too.
+        pendingSignatureMark = null
         screen = Screen.FillMark
     }
 
@@ -240,7 +244,11 @@ fun FontCreatorApp(
                         initialImageText = ""
                         imagePicker.launch("image/*")
                     },
-                    openFillMark = { screen = Screen.FillMark },
+                    openFillMark = {
+                        fillMarkUri = null
+                        pendingSignatureMark = null
+                        screen = Screen.FillMark
+                    },
                     openFonts = { screen = Screen.Fonts },
                     openSignatures = { screen = Screen.Signatures },
                     openStamps = { screen = Screen.Stamps },
@@ -260,7 +268,8 @@ fun FontCreatorApp(
                     back = { screen = Screen.Home },
                     useInDocument = { markName ->
                         pendingSignatureMark = markName
-                        screen = Screen.Signature
+                        fillMarkUri = null
+                        screen = Screen.FillMark
                     },
                 )
                 Screen.Stamps -> StampsModuleScreen(
@@ -268,7 +277,8 @@ fun FontCreatorApp(
                     back = { screen = Screen.Home },
                     useInDocument = { markName ->
                         pendingSignatureMark = markName
-                        screen = Screen.Signature
+                        fillMarkUri = null
+                        screen = Screen.FillMark
                     },
                 )
                 Screen.FontCelebration -> {
@@ -310,17 +320,13 @@ fun FontCreatorApp(
                         imagePicker.launch("image/*")
                     },
                 )
-                Screen.Signature -> SignatureScreen(
-                    vm = viewModel,
-                    initialMarkName = pendingSignatureMark,
-                    onInitialMarkConsumed = { pendingSignatureMark = null },
-                    back = { pendingSignatureMark = null; screen = Screen.Home },
-                )
                 Screen.FillMark -> FillMarkScreen(
                     vm = viewModel,
                     initialUri = fillMarkUri,
+                    initialMarkName = pendingSignatureMark,
                     back = {
                         fillMarkUri = null
+                        pendingSignatureMark = null
                         screen = Screen.Home
                     },
                 )

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorScreen.kt
@@ -457,31 +457,6 @@ private fun appTypography(fontFamily: FontFamily?): Typography {
         }
     }
     HorizontalDivider()
-    // Letter reference font picker
-    val referenceFontOptions = remember(vm.projects, vm.importedFonts) {
-        val builtIn = listOf("Default", "Sans-serif", "Serif", "Monospace")
-        val userFontNames = vm.allFontOptions().map { it.first }
-        builtIn + userFontNames
-    }
-    var refExpanded by remember { mutableStateOf(false) }
-    Text("Letter reference font", style = MaterialTheme.typography.titleMedium)
-    Text(
-        "A faint guide glyph shown while drawing letters. Does not affect the app font.",
-        style = MaterialTheme.typography.bodySmall,
-    )
-    Box {
-        OutlinedButton({ refExpanded = true }, Modifier.fillMaxWidth()) { Text(vm.referenceFontKey) }
-        DropdownMenu(refExpanded, { refExpanded = false }) {
-            referenceFontOptions.forEach { key ->
-                DropdownMenuItem(
-                    text = { Text(key) },
-                    onClick = { vm.setReferenceFont(key); refExpanded = false },
-                    trailingIcon = { if (key == vm.referenceFontKey) Text("âœ“") },
-                )
-            }
-        }
-    }
-    HorizontalDivider()
     Text("Privacy & storage", style = MaterialTheme.typography.titleMedium)
     Text(
         "All fonts, signatures, and generated files are stored locally on this device.",

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -585,6 +585,24 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
         return true
     }
 
+    /** Updates an existing signature's name and redrawn strokes in place -- unlike
+     *  [saveSignature], which is create-only and rejects any name already in use, including
+     *  the signature's own current name. Used by the signature editor's edit flow. */
+    fun updateSignature(originalName: String, newName: String, strokes: List<GlyphStroke>, canvasWidth: Float, canvasHeight: Float): Boolean {
+        val index = signatures.indexOfFirst { it.name == originalName }
+        if (index < 0) return false
+        val clean = newName.trim().ifEmpty { originalName }
+        val duplicate = signatures.withIndex().any { (idx, signature) ->
+            idx != index && signature.name.equals(clean, ignoreCase = true)
+        }
+        if (duplicate) return false
+        val existing = signatures[index]
+        signatures[index] = existing.copy(name = clean, strokes = strokes, canvasWidth = canvasWidth.coerceAtLeast(1f), canvasHeight = canvasHeight.coerceAtLeast(1f))
+        if (defaultSignatureName == originalName) setDefaultSignature(clean)
+        persistSignatures()
+        return true
+    }
+
     fun deleteSignature(name: String) {
         val index = signatures.indexOfFirst { it.name == name }
         if (index >= 0) {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -97,14 +97,23 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
     /** Returns all available typefaces (generated + imported) with their display labels. */
     fun hasGeneratedFont(name: String): Boolean = generatedFile(name).exists()
 
-    fun allFontOptions(): List<Pair<String, Typeface>> {
+    /**
+     * All usable typefaces (generated + imported), most recently modified/imported first --
+     * so a caller that just wants "one sensible default font" (Fill & Mark, or "Use font on
+     * image"'s own fallback) can simply take the first entry instead of getting creation order.
+     *
+     * [completeOnly] excludes a created font missing glyphs for some of its own selected
+     * characters. Fill & Mark passes true, since arbitrary typed text there could hit an
+     * undrawn glyph; "Use font on image" leaves it false because an incomplete (phrase-mode)
+     * font can still render the specific phrase it was drawn for. Either way, the fonts library
+     * screen is unaffected and still lists an incomplete font with its own "x of y" progress.
+     */
+    fun allFontOptions(completeOnly: Boolean = false): List<Pair<String, Typeface>> {
         val app = getApplication<Application>()
+        data class Entry(val name: String, val typeface: Typeface, val modifiedAt: Long)
         val generated = projects.mapNotNull { project ->
-            // An incomplete font is missing glyphs for some of its own selected characters --
-            // offering it here would let it be picked to write arbitrary text that then renders
-            // with gaps for whatever hasn't been drawn yet. The fonts library screen still shows
-            // it (with its "x of y" progress), just not as a usable font elsewhere until done.
-            if (!isProjectComplete(project)) return@mapNotNull null
+            if (project.drawings.isEmpty()) return@mapNotNull null
+            if (completeOnly && !isProjectComplete(project)) return@mapNotNull null
             val file = generatedFile(project.name)
             runCatching {
                 // Keep Library fonts usable and current even if the user has not opened Preview.
@@ -116,14 +125,14 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
                         project.name,
                     ),
                 )
-                project.name to loadTypeface(file)
+                Entry(project.name, loadTypeface(file), project.lastModifiedAt)
             }.getOrNull()
         }
         val imported = importedFonts.mapNotNull { font ->
             val file = File(app.filesDir, font.fileName)
-            if (file.exists()) runCatching { font.displayName to loadTypeface(file) }.getOrNull() else null
+            if (file.exists()) runCatching { Entry(font.displayName, loadTypeface(file), font.importedAt) }.getOrNull() else null
         }
-        return generated + imported
+        return (generated + imported).sortedByDescending { it.modifiedAt }.map { it.name to it.typeface }
     }
 
     fun createProject(name: String): Boolean {

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontStudioScreens.kt
@@ -66,13 +66,19 @@ import com.jaafar.remoteconfig.R
         Page("Fine-tune your font", back) { Text("Choose a handwriting font first.") }
         return
     }
-    var letterSpacing by remember(project.name) { mutableFloatStateOf(project.letterSpacingMm) }
-    var wordSpacing by remember(project.name) { mutableFloatStateOf(project.wordSpacingMm) }
+    // Clamped to the sliders' own ranges below, not just setSpacing's wider validity check --
+    // a font saved with a spacing value from before these ranges were narrowed (or otherwise
+    // outside them) would hand the Slider a value past its valueRange, which crashed it.
+    var letterSpacing by remember(project.name) { mutableFloatStateOf(project.letterSpacingMm.coerceIn(LETTER_SPACING_RANGE)) }
+    var wordSpacing by remember(project.name) { mutableFloatStateOf(project.wordSpacingMm.coerceIn(WORD_SPACING_RANGE)) }
     val updateSpacing: (Float, Float) -> Unit = { nextLetter, nextWord ->
         letterSpacing = nextLetter
         wordSpacing = nextWord
         if (vm.setSpacing(nextLetter.toString(), nextWord.toString())) vm.generate()
     }
+    // Word spacing has no visible effect with only one word in the preview -- there's nothing
+    // to space apart -- so its control is disabled rather than left inertly interactive.
+    val previewWordCount = previewText.trim().split(Regex("\\s+")).count { it.isNotBlank() }
 
     // Matches the iOS app's "Fine-tune your font" screen: the preview *is* the screen --
     // a big live-rendered card with the text field woven directly into it, a single
@@ -122,8 +128,11 @@ import com.jaafar.remoteconfig.R
                     // advance widths are clamped to 500..4096 / 100..4096 font units) --
                     // the previous wider ranges mostly got silently clamped to the same
                     // value, so dragging looked like it did something but had no effect.
-                    SpacingSlider("Letter spacing", letterSpacing, -3f..4f, 0.25f) { updateSpacing(it, wordSpacing) }
-                    SpacingSlider("Word spacing", wordSpacing, 0.25f..8f, 0.25f) { updateSpacing(letterSpacing, it) }
+                    SpacingSlider("Letter spacing", letterSpacing, LETTER_SPACING_RANGE, 0.25f) { updateSpacing(it, wordSpacing) }
+                    SpacingSlider(
+                        "Word spacing", wordSpacing, WORD_SPACING_RANGE, 0.25f,
+                        enabled = previewWordCount > 1,
+                    ) { updateSpacing(letterSpacing, it) }
                     Text(
                         "Changes save automatically.",
                         style = MaterialTheme.typography.bodySmall,
@@ -141,28 +150,40 @@ import com.jaafar.remoteconfig.R
     }
 }
 
+private val LETTER_SPACING_RANGE = -3f..4f
+private val WORD_SPACING_RANGE = 0.25f..8f
+
 @Composable
 private fun SpacingSlider(
     label: String,
     value: Float,
     range: ClosedFloatingPointRange<Float>,
     step: Float,
+    enabled: Boolean = true,
     onChange: (Float) -> Unit,
 ) {
+    val contentAlpha = if (enabled) 1f else 0.38f
     Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(label, style = MaterialTheme.typography.titleMedium)
+            Text(
+                label,
+                style = MaterialTheme.typography.titleMedium,
+                color = LocalContentColor.current.copy(alpha = contentAlpha),
+            )
             Text(
                 "${String.format(java.util.Locale.US, "%.2f", value)} mm",
                 style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
             )
         }
         Slider(
             value = value,
             onValueChange = onChange,
             valueRange = range,
-            steps = ((range.endInclusive - range.start) / step).toInt() - 1,
+            // coerceAtLeast(0): Slider requires steps >= 0 -- defensive against a range/step
+            // combination that would otherwise compute negative and crash it.
+            steps = (((range.endInclusive - range.start) / step).toInt() - 1).coerceAtLeast(0),
+            enabled = enabled,
         )
     }
 }

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignatureScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignatureScreen.kt
@@ -3,7 +3,6 @@ package com.jaafar.remoteconfig.fontcreator
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Canvas
@@ -12,7 +11,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,27 +21,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -51,7 +39,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color as ComposeColor
 import androidx.compose.ui.graphics.Path as ComposePath
 import androidx.compose.ui.graphics.StrokeCap
@@ -61,196 +48,12 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
-
-private enum class SignaturePage { Library, Editor, ImportStamp, Apply }
-
-@Composable
-internal fun SignatureScreen(
-    vm: FontCreatorViewModel,
-    back: () -> Unit,
-    initialMarkName: String? = null,
-    onInitialMarkConsumed: () -> Unit = {},
-) {
-    // When launched from the library with a pre-selected mark, jump straight to Apply.
-    var page by remember {
-        mutableStateOf(
-            if (initialMarkName != null && vm.signatures.any { it.name == initialMarkName })
-                SignaturePage.Apply
-            else
-                SignaturePage.Library
-        )
-    }
-    // Auto-select the provided mark or, if none, the first available signature/stamp.
-    var selectedSignatureName by remember {
-        mutableStateOf(
-            initialMarkName?.takeIf { name -> vm.signatures.any { it.name == name } }
-                ?: vm.signatures.firstOrNull()?.name
-        )
-    }
-
-    // Consume the initial mark name immediately so it is not replayed on the next composition.
-    LaunchedEffect(Unit) { onInitialMarkConsumed() }
-
-    // Handle the device back button so it mirrors the in-screen back button behaviour.
-    BackHandler(enabled = page != SignaturePage.Library) {
-        when (page) {
-            SignaturePage.Editor, SignaturePage.ImportStamp -> page = SignaturePage.Library
-            SignaturePage.Apply -> back()
-            SignaturePage.Library -> Unit
-        }
-    }
-
-    when (page) {
-        SignaturePage.Library -> SignatureLibraryScreen(
-            vm = vm,
-            selectedSignatureName = selectedSignatureName,
-            onSelect = { name -> selectedSignatureName = name },
-            onCreateNew = { page = SignaturePage.Editor },
-            onImportStamp = { page = SignaturePage.ImportStamp },
-            onUseSelected = { page = SignaturePage.Apply },
-            back = back,
-        )
-        SignaturePage.Editor -> SignatureEditorScreen(
-            vm = vm,
-            onSaved = { name ->
-                selectedSignatureName = name
-                page = SignaturePage.Apply
-            },
-            back = { page = SignaturePage.Library },
-        )
-        SignaturePage.ImportStamp -> ImportStampFromImageScreen(
-            vm = vm,
-            onSaved = { name ->
-                selectedSignatureName = name
-                page = SignaturePage.Apply
-            },
-            back = { page = SignaturePage.Library },
-        )
-        SignaturePage.Apply -> {
-            val sig = vm.signatures.firstOrNull { it.name == selectedSignatureName }
-            ApplySignatureScreen(
-                vm = vm,
-                signature = sig,
-                onAddMark = { page = SignaturePage.Library },
-                back = back,
-            )
-        }
-    }
-}
-
-@Composable
-private fun SignatureLibraryScreen(
-    vm: FontCreatorViewModel,
-    selectedSignatureName: String?,
-    onSelect: (String) -> Unit,
-    onCreateNew: () -> Unit,
-    onImportStamp: () -> Unit,
-    onUseSelected: () -> Unit,
-    back: () -> Unit,
-) {
-    val signatures = vm.signatures.filter { it.imageFileName == null }
-    val stamps = vm.signatures.filter { it.imageFileName != null }
-
-    Page("Signatures & Stamps", back) {
-        if (vm.signatures.isEmpty()) {
-            Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    Text("No saved signatures or stamps yet.", style = MaterialTheme.typography.bodyLarge)
-                    Button(onClick = onCreateNew) { Text("Draw a signature") }
-                    OutlinedButton(onClick = onImportStamp) { Text("Import a stamp") }
-                }
-            }
-        } else {
-            LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (signatures.isNotEmpty()) {
-                    item { Text("Signatures", style = MaterialTheme.typography.titleSmall, modifier = Modifier.padding(top = 4.dp)) }
-                    items(signatures, key = { it.name }) { signature ->
-                        MarkLibraryItem(
-                            mark = signature,
-                            isSelected = signature.name == selectedSignatureName,
-                            onSelect = { onSelect(signature.name) },
-                            onDelete = {
-                                vm.deleteSignature(signature.name)
-                                if (selectedSignatureName == signature.name) {
-                                    onSelect(vm.signatures.firstOrNull()?.name ?: "")
-                                }
-                            },
-                        )
-                    }
-                }
-                if (stamps.isNotEmpty()) {
-                    item { Text("Stamps", style = MaterialTheme.typography.titleSmall, modifier = Modifier.padding(top = 8.dp)) }
-                    items(stamps, key = { it.name }) { stamp ->
-                        MarkLibraryItem(
-                            mark = stamp,
-                            isSelected = stamp.name == selectedSignatureName,
-                            onSelect = { onSelect(stamp.name) },
-                            onDelete = {
-                                vm.deleteSignature(stamp.name)
-                                if (selectedSignatureName == stamp.name) {
-                                    onSelect(vm.signatures.firstOrNull()?.name ?: "")
-                                }
-                            },
-                        )
-                    }
-                }
-            }
-            HorizontalDivider()
-            OutlinedButton(onClick = onCreateNew, modifier = Modifier.fillMaxWidth()) { Text("Draw a new signature") }
-            OutlinedButton(onClick = onImportStamp, modifier = Modifier.fillMaxWidth()) { Text("Import a new stamp") }
-            Button(
-                onClick = onUseSelected,
-                modifier = Modifier.fillMaxWidth(),
-                enabled = selectedSignatureName != null && vm.signatures.any { it.name == selectedSignatureName },
-            ) {
-                Text("Use selected mark")
-            }
-        }
-    }
-}
-
-@Composable
-private fun MarkLibraryItem(
-    mark: SavedSignature,
-    isSelected: Boolean,
-    onSelect: () -> Unit,
-    onDelete: () -> Unit,
-) {
-    OutlinedCard(
-        Modifier.fillMaxWidth().border(
-            width = if (isSelected) 2.dp else 1.dp,
-            color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
-            shape = MaterialTheme.shapes.medium,
-        ).clickable { onSelect() }
-    ) {
-        Row(
-            Modifier.fillMaxWidth().padding(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            RadioButton(selected = isSelected, onClick = onSelect)
-            SignaturePreview(Modifier.size(88.dp, 56.dp), mark)
-            Column(Modifier.weight(1f)) {
-                Text(mark.name, style = MaterialTheme.typography.titleSmall)
-                Text(
-                    if (mark.imageFileName != null) "Stamp" else "Signature",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                if (isSelected) Text("Selected", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
-            }
-            OutlinedButton(onClick = onDelete) { Text("Delete") }
-        }
-    }
-}
 
 @Composable
 internal fun ImportStampFromImageScreen(
@@ -382,15 +185,21 @@ internal fun SignatureEditorScreen(
     vm: FontCreatorViewModel,
     onSaved: (String) -> Unit,
     back: () -> Unit,
+    existing: SavedSignature? = null,
+    useInFillMark: ((String) -> Unit)? = null,
 ) {
-    var name by remember { mutableStateOf(vm.suggestedSignatureName("My signature")) }
-    var strokes by remember { mutableStateOf<List<GlyphStroke>>(emptyList()) }
+    var name by remember { mutableStateOf(existing?.name ?: vm.suggestedSignatureName("My signature")) }
+    var strokes by remember { mutableStateOf(existing?.strokes ?: emptyList()) }
     var active by remember { mutableStateOf<List<GlyphPoint>>(emptyList()) }
     var canvasSize by remember { mutableStateOf(1f to 1f) }
     var status by remember { mutableStateOf("") }
-    val duplicateName = name.trim().isNotEmpty() && vm.hasSavedSignatureName(name)
+    // Excludes the signature's own current name -- editing it back to what it already was
+    // isn't a duplicate, unlike creating a brand new one under a name already in use.
+    val duplicateName = name.trim().isNotEmpty() &&
+        !name.trim().equals(existing?.name, ignoreCase = true) &&
+        vm.hasSavedSignatureName(name)
 
-    Page("New Signature", back, scrollable = true) {
+    Page(if (existing != null) "Edit Signature" else "New Signature", back, scrollable = true) {
         OutlinedTextField(
             value = name,
             onValueChange = { name = it },
@@ -447,7 +256,11 @@ internal fun SignatureEditorScreen(
                         status = "A saved signature or stamp already uses that name."
                         return@Button
                     }
-                    val savedName = vm.saveSignature(name, strokes, canvasSize.first, canvasSize.second)
+                    val savedName = if (existing != null) {
+                        if (vm.updateSignature(existing.name, name, strokes, canvasSize.first, canvasSize.second)) name.trim().ifEmpty { existing.name } else null
+                    } else {
+                        vm.saveSignature(name, strokes, canvasSize.first, canvasSize.second)
+                    }
                     if (savedName != null) {
                         status = "Saved."
                         onSaved(savedName)
@@ -457,262 +270,17 @@ internal fun SignatureEditorScreen(
                 },
                 enabled = strokes.isNotEmpty() && !duplicateName,
                 modifier = Modifier.weight(1f),
-            ) { Text("Save signature") }
+            ) { Text(if (existing != null) "Save changes" else "Save signature") }
+        }
+        // Signing/stamping a document is now Fill & Mark's job -- this just gets you there
+        // with this signature ready to place, instead of a separate bespoke sign-a-document
+        // screen duplicating what Fill & Mark already does.
+        if (existing != null && useInFillMark != null) {
+            OutlinedButton(onClick = { useInFillMark(existing.name) }, modifier = Modifier.fillMaxWidth()) {
+                Text("Use in Fill & Mark")
+            }
         }
         if (status.isNotBlank()) Text(status, style = MaterialTheme.typography.bodySmall)
-    }
-}
-
-@Composable
-private fun ApplySignatureScreen(
-    vm: FontCreatorViewModel,
-    signature: SavedSignature?,
-    onAddMark: () -> Unit,
-    back: () -> Unit,
-) {
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    val signatureImageFile = signature?.let { vm.signatureImageFile(it) }
-    val signatureImageBitmap = rememberImageBitmap(signatureImageFile)
-    var signatureScale by remember { mutableFloatStateOf(22f) }
-    var sigOffsetX by remember { mutableFloatStateOf(0.5f) }
-    var sigOffsetY by remember { mutableFloatStateOf(0.82f) }
-    var isProcessing by remember { mutableStateOf(false) }
-    var status by remember { mutableStateOf("") }
-
-    var selectedFileUri by remember { mutableStateOf<Uri?>(null) }
-    var isPdf by remember { mutableStateOf(false) }
-    var previewBitmap by remember { mutableStateOf<Bitmap?>(null) }
-    var currentPage by remember { mutableIntStateOf(0) }
-    var pageCount by remember { mutableIntStateOf(0) }
-    var applyToAll by remember { mutableStateOf(false) }
-    DisposableEffect(previewBitmap) {
-        val bitmapToRecycle = previewBitmap
-        onDispose { bitmapToRecycle?.recycle() }
-    }
-
-    LaunchedEffect(selectedFileUri, currentPage) {
-        val uri = selectedFileUri ?: return@LaunchedEffect
-        if (!isPdf) return@LaunchedEffect
-        val bitmap = withContext(Dispatchers.IO) { renderPdfPage(context, uri, currentPage) }
-        if (bitmap != null) {
-            previewBitmap = bitmap
-        }
-    }
-
-    val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
-        if (uri != null) {
-            selectedFileUri = uri
-            status = ""
-            sigOffsetX = 0.5f
-            sigOffsetY = 0.82f
-            scope.launch {
-                val mimeType = context.contentResolver.getType(uri)
-                val looksLikePdf = displayNameForUri(context, uri)?.endsWith(".pdf", true) == true
-                if (mimeType == "application/pdf" || looksLikePdf) {
-                    isPdf = true
-                    currentPage = 0
-                    applyToAll = false
-                    val count = withContext(Dispatchers.IO) { getPdfPageCount(context, uri) }
-                    pageCount = count
-                    val bitmap = withContext(Dispatchers.IO) { renderPdfPage(context, uri, 0) }
-                    previewBitmap = bitmap
-                } else {
-                    isPdf = false
-                    pageCount = 0
-                    val bitmap = withContext(Dispatchers.IO) { loadBitmap(context.contentResolver, uri) }
-                    previewBitmap = bitmap
-                }
-            }
-        }
-    }
-
-    Page("Sign or Stamp a Document", back) {
-        Column(
-            Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            OutlinedCard(Modifier.fillMaxWidth()) {
-                Row(Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    if (signature != null) {
-                        SignaturePreview(Modifier.size(88.dp, 56.dp), signature)
-                        Text(signature.name, style = MaterialTheme.typography.titleSmall, modifier = Modifier.weight(1f))
-                        OutlinedButton(onClick = onAddMark) { Text("Change mark") }
-                    } else {
-                        Text(
-                            "No mark selected.",
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Button(onClick = onAddMark) { Text("Add mark") }
-                    }
-                }
-            }
-
-            if (signature != null) {
-                Text("Mark size", style = MaterialTheme.typography.titleMedium)
-                Slider(value = signatureScale, onValueChange = { signatureScale = it }, valueRange = 12f..35f)
-                Text("${signatureScale.toInt()}% of page width", style = MaterialTheme.typography.bodySmall)
-
-                HorizontalDivider()
-            }
-
-            OutlinedButton(
-                onClick = { picker.launch(arrayOf("application/pdf", "image/*")) },
-                modifier = Modifier.fillMaxWidth(),
-                enabled = !isProcessing,
-            ) {
-                Text(if (selectedFileUri == null) "Choose image or PDF" else "Choose a different file")
-            }
-
-            if (selectedFileUri == null) {
-                Text(
-                    "Choose a document above to see the mark placement preview.",
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-
-            if (selectedFileUri != null) {
-                val bitmap = previewBitmap
-                if (bitmap != null) {
-                    Text("Mark placement", style = MaterialTheme.typography.titleMedium)
-                    Text("Drag the mark to position it.", style = MaterialTheme.typography.bodySmall)
-
-                    if (isPdf && pageCount > 0) {
-                        Row(
-                            Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            OutlinedButton(onClick = { if (currentPage > 0) currentPage-- }, enabled = currentPage > 0) { Text("\u2190 Previous") }
-                            Text("Page ${currentPage + 1} of $pageCount", modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
-                            OutlinedButton(onClick = { if (currentPage < pageCount - 1) currentPage++ }, enabled = currentPage < pageCount - 1) { Text("Next \u2192") }
-                        }
-
-                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            if (!applyToAll) {
-                                Button(onClick = { applyToAll = false }, modifier = Modifier.weight(1f)) { Text("Apply to this page") }
-                                OutlinedButton(onClick = { applyToAll = true }, modifier = Modifier.weight(1f)) { Text("Apply to all pages") }
-                            } else {
-                                OutlinedButton(onClick = { applyToAll = false }, modifier = Modifier.weight(1f)) { Text("Apply to this page") }
-                                Button(onClick = { applyToAll = true }, modifier = Modifier.weight(1f)) { Text("Apply to all pages") }
-                            }
-                        }
-                    }
-
-                    val previewAspect = bitmap.width.toFloat() / bitmap.height.toFloat()
-                    Box(
-                        Modifier.fillMaxWidth().aspectRatio(previewAspect).border(1.dp, ComposeColor.Gray),
-                    ) {
-                        Image(
-                            bitmap = bitmap.asImageBitmap(),
-                            contentDescription = null,
-                            modifier = Modifier.fillMaxSize(),
-                            contentScale = ContentScale.Fit,
-                        )
-                        Canvas(
-                            modifier = Modifier.fillMaxSize()
-                                .pointerInput(Unit) {
-                                    detectTapGestures { offset ->
-                                        sigOffsetX = (offset.x / size.width).coerceIn(0f, 1f)
-                                        sigOffsetY = (offset.y / size.height).coerceIn(0f, 1f)
-                                    }
-                                }
-                                .pointerInput(Unit) {
-                                    detectDragGestures(
-                                        onDragStart = { offset ->
-                                            sigOffsetX = (offset.x / size.width).coerceIn(0f, 1f)
-                                            sigOffsetY = (offset.y / size.height).coerceIn(0f, 1f)
-                                        },
-                                        onDrag = { change, _ ->
-                                            change.consume()
-                                            sigOffsetX = (change.position.x / size.width).coerceIn(0f, 1f)
-                                            sigOffsetY = (change.position.y / size.height).coerceIn(0f, 1f)
-                                        },
-                                    )
-                                },
-                        ) {
-                            val sigPoints = if (signatureImageBitmap == null && signature != null) signature.strokes.flatMap { it.points } else emptyList()
-                            if (signatureImageBitmap != null || sigPoints.isNotEmpty()) {
-                                val sigNatWidth = signatureImageBitmap?.width?.toFloat()?.coerceAtLeast(1f)
-                                    ?: (sigPoints.maxOf { it.x } - sigPoints.minOf { it.x }).coerceAtLeast(1f)
-                                val sigNatHeight = signatureImageBitmap?.height?.toFloat()?.coerceAtLeast(1f)
-                                    ?: (sigPoints.maxOf { it.y } - sigPoints.minOf { it.y }).coerceAtLeast(1f)
-                                val targetSigWidth = size.width * (signatureScale / 100f).coerceIn(0.12f, 0.35f)
-                                val scale = targetSigWidth / sigNatWidth
-                                val left = (sigOffsetX * size.width).coerceIn(0f, (size.width - sigNatWidth * scale).coerceAtLeast(0f))
-                                val top = (sigOffsetY * size.height).coerceIn(0f, (size.height - sigNatHeight * scale).coerceAtLeast(0f))
-                                if (signatureImageBitmap != null) {
-                                    drawImage(
-                                        image = signatureImageBitmap.asImageBitmap(),
-                                        dstOffset = IntOffset(left.toInt(), top.toInt()),
-                                        dstSize = IntSize((sigNatWidth * scale).toInt(), (sigNatHeight * scale).toInt()),
-                                    )
-                                } else if (signature != null) {
-                                    val minX = sigPoints.minOf { it.x }
-                                    val minY = sigPoints.minOf { it.y }
-                                    signature.strokes.forEach { stroke ->
-                                        if (stroke.points.size > 1) {
-                                            drawPath(
-                                                ComposePath().apply {
-                                                    moveTo(left + (stroke.points.first().x - minX) * scale, top + (stroke.points.first().y - minY) * scale)
-                                                    stroke.points.drop(1).forEach { pt ->
-                                                        lineTo(left + (pt.x - minX) * scale, top + (pt.y - minY) * scale)
-                                                    }
-                                                },
-                                                ComposeColor.Black,
-                                                style = Stroke(width = 3f, cap = StrokeCap.Round, join = StrokeJoin.Round),
-                                            )
-                                        }
-                                    }
-                                }
-                                drawRect(
-                                    color = ComposeColor(0x44_1565C0),
-                                    topLeft = Offset(left, top),
-                                    size = androidx.compose.ui.geometry.Size(sigNatWidth * scale, sigNatHeight * scale),
-                                )
-                            }
-                        }
-                    }
-
-                    Button(
-                        onClick = {
-                            val uri = selectedFileUri ?: return@Button
-                            val sig = signature ?: return@Button
-                            scope.launch {
-                                isProcessing = true
-                                status = "Applying mark\u2026"
-                                val result = withContext(Dispatchers.IO) {
-                                    signDocumentWithPage(
-                                        context, uri, sig,
-                                        signatureScale / 100f, sigOffsetX, sigOffsetY,
-                                        if (isPdf) currentPage else 0,
-                                        if (isPdf) applyToAll else false,
-                                    )
-                                }
-                                isProcessing = false
-                                if (result != null) {
-                                    shareDocument(context, result.file, result.mimeType)
-                                    status = "Signed ${if (result.mimeType == "application/pdf") "PDF" else "image"} ready to share."
-                                } else {
-                                    status = "Unable to sign the selected file."
-                                }
-                            }
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        enabled = !isProcessing && signature != null,
-                    ) {
-                        Text("Apply mark and share")
-                    }
-                } else {
-                    LinearProgressIndicator(Modifier.fillMaxWidth())
-                    Text("Loading preview\u2026", style = MaterialTheme.typography.bodySmall)
-                }
-            }
-
-            if (isProcessing) LinearProgressIndicator(Modifier.fillMaxWidth())
-            if (status.isNotBlank()) Text(status, style = MaterialTheme.typography.bodySmall)
-        }
     }
 }
 

--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignaturesModuleScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignaturesModuleScreen.kt
@@ -1,9 +1,11 @@
 package com.jaafar.remoteconfig.fontcreator
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Draw
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -16,8 +18,21 @@ import androidx.compose.ui.unit.dp
 @Composable
 internal fun SignaturesModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, useInDocument: (String) -> Unit) {
     var creating by remember { mutableStateOf(false) }
+    var editing by remember { mutableStateOf<SavedSignature?>(null) }
     if (creating) {
         SignatureEditorScreen(vm = vm, onSaved = { creating = false }, back = { creating = false })
+        return
+    }
+    // Opened by tapping a row below -- rename, redraw, and "Use in Fill & Mark" all live here
+    // now, instead of a separate action dialog over the list.
+    editing?.let { mark ->
+        SignatureEditorScreen(
+            vm = vm,
+            existing = mark,
+            onSaved = { editing = null },
+            useInFillMark = { name -> editing = null; useInDocument(name) },
+            back = { editing = null },
+        )
         return
     }
     val signatures = vm.signatures.filter { it.imageFileName == null }
@@ -52,8 +67,30 @@ internal fun SignaturesModuleScreen(vm: FontCreatorViewModel, back: () -> Unit, 
         } else {
             LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(signatures, key = { it.name }) { signature ->
-                    SavedMarkCard(vm, signature, useInDocument)
+                    SignatureRow(vm, signature) { editing = signature }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * One signature row: delete only, no inline rename -- tapping the row opens the signature
+ * editor, where the name (and the drawing itself) can be changed, and from which it can be
+ * sent straight into Fill & Mark.
+ */
+@Composable
+private fun SignatureRow(vm: FontCreatorViewModel, mark: SavedSignature, onClick: () -> Unit) {
+    OutlinedCard(Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Row(
+            Modifier.fillMaxWidth().padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SignaturePreview(Modifier.size(88.dp, 56.dp), mark)
+            Text(mark.name, style = MaterialTheme.typography.titleMedium, modifier = Modifier.weight(1f))
+            IconButton(onClick = { vm.deleteSignature(mark.name) }) {
+                Icon(Icons.Filled.Delete, contentDescription = "Delete ${mark.name}")
             }
         }
     }


### PR DESCRIPTION
## Summary

**1. Signatures: edit in place (rename/redraw), use directly in Fill & Mark**
- Tapping a signature now opens an edit screen instead of an actions dialog: rename, redraw (Clear/Undo/Save, same as creating a new one), and a "Use in Fill & Mark" action — which sends you to Fill & Mark's own document picker, then places that signature at the center of whatever document you choose.
- The signature list itself now shows only a delete icon per row; rename lives in the edit screen instead.
- Stamps and their existing inline rename/delete are unchanged, but their own "use in a document" action now goes through the same Fill & Mark auto-placement instead of the old bespoke "Sign or Stamp a Document" screen — which is removed along with the rest of the now-unreachable Signature-picker flow it lived behind (that flow always jumped straight past its own library/apply pages once a mark name was supplied, which was always the case).

**2. Removed Letter reference font setting; smarter font defaults**
- Removed the "Letter reference font" section from Settings. The underlying guide-glyph mechanism it configured is untouched, it just always uses its original default now, with no way to change it.
- `allFontOptions()` now takes a `completeOnly` flag and sorts results by recency. Fill & Mark passes `true` (arbitrary typed text could hit an undrawn glyph on an in-progress font), "Use font on image" keeps the old default of `false` (an incomplete/phrase-mode font can still write the specific phrase it was drawn for). Fill & Mark's font picker defaults to the user's own most recently modified font instead of the system font, since the list is already sorted that way.

**3. Fine-tune fixes**
- Word spacing is disabled when the preview text is a single word, since there's nothing to space apart.
- Fixed a crash adjusting spacing in Fine-tune: a font's saved spacing value could be outside the sliders' `valueRange` (e.g. one set before the ranges were narrowed), which crashed the Slider. Values are now clamped to the slider ranges on load, and the steps calculation is defensively floored at 0.

## Notes
- I could not run a full Gradle build here — this environment's network policy blocks `dl.google.com` (Android Gradle Plugin's Maven repo). I did careful manual review instead, following patterns already used and CI-validated elsewhere in this codebase. Please have CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz