### PR TITLE
Fill & Mark: skip the landing screen when arriving with a mark to place

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -247,6 +247,10 @@ internal fun FillMarkScreen(
         FillMarkLandingScreen(
             onDocumentChosen = { uri -> documentUri = uri },
             back = back,
+            // Arriving with a mark already chosen (Signatures/Stamps' "Use in Fill & Mark")
+            // means the document picker is the only thing left to do here -- skip the "Choose
+            // PDF or image" tap-through and open the system picker immediately instead.
+            autoLaunchPicker = initialMarkName != null,
         )
     } else {
         FillMarkEditorScreen(
@@ -266,6 +270,7 @@ internal fun FillMarkScreen(
 private fun FillMarkLandingScreen(
     onDocumentChosen: (Uri) -> Unit,
     back: () -> Unit,
+    autoLaunchPicker: Boolean = false,
 ) {
     val context = LocalContext.current
     var recentDocs by remember { mutableStateOf(loadRecentDocs(context)) }
@@ -283,6 +288,12 @@ private fun FillMarkLandingScreen(
         saveRecentDoc(context, uri.toString(), name)
         recentDocs = loadRecentDocs(context)
         onDocumentChosen(uri)
+    }
+
+    // Opens the system picker immediately instead of waiting for the button tap below --
+    // only if the picker gets cancelled does this screen's own UI end up being needed.
+    LaunchedEffect(autoLaunchPicker) {
+        if (autoLaunchPicker) picker.launch(arrayOf("application/pdf", "image/*"))
     }
 
     Page("Complete a document", back) {


### PR DESCRIPTION
## Summary
- "Use in Fill & Mark" from an existing signature/stamp now opens the system document picker immediately instead of first showing "Complete a document" and waiting for the "Choose PDF or image" button tap.
- The plain dashboard "Fill & Mark" tile is unaffected — it still shows the landing screen (with recent documents) as before.

## Notes
- I could not run a full Gradle build here — this environment's network policy blocks `dl.google.com` (Android Gradle Plugin's Maven repo). I did careful manual review instead, following patterns already used and CI-validated elsewhere in this codebase. Please have CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz

---
_Generated by [Claude Code](https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz)_