### PR TITLE
Fix Fill & Mark back button reopening the document picker

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -182,7 +182,11 @@ internal fun FillMarkScreen(
             vm = vm,
             documentUri = documentUri!!,
             initialMarkName = initialMarkName,
-            back = { documentUri = null },
+            // Exits Fill & Mark entirely, matching this back button everywhere else in the
+            // app -- previously this reset to the document picker instead, which (now that
+            // picker auto-launches immediately, with no landing screen to land on) meant back
+            // just bounced straight into the system file picker again.
+            back = back,
         )
     }
 }


### PR DESCRIPTION
## Summary
- Pressing back from the Fill & Mark editor was resetting `documentUri` to null instead of exiting the screen. That used to land on a visible "Complete a document" screen (pick a different document, or back out again), but now that screen auto-launches the system file picker immediately with nothing to land on -- so back just bounced straight into the system picker again, which read as "back does nothing."
- Back now calls the screen's own `back` callback directly, exiting Fill & Mark entirely -- consistent with every other screen in the app.

## Test plan
- [ ] Open Fill & Mark from the dashboard, pick a document, then tap back from the editor -- should return to the dashboard, not reopen the file picker.
- [ ] Open Fill & Mark via a signature/stamp's "Use in Fill & Mark", pick a document, then tap back from the editor -- should return to wherever that flow was entered from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz

---
_Generated by [Claude Code](https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz)_