### PR TITLE
Use font on image: icon-only toolbar controls, slightly larger

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -511,9 +511,10 @@ fun ImageTextEditorScreen(
     }
 }
 
-// Icon above a small label, matching the iOS app's write-on-image toolbar (SF Symbols
+// Icon-only, matching the iOS app's write-on-image toolbar (SF Symbols
 // plus/textformat/textformat.size/paintpalette there; the closest standard Material
-// icons here), instead of plain text-only buttons.
+// icons here). label is kept as the accessibility description since there's no
+// visible text anymore.
 @Composable
 private fun androidx.compose.foundation.layout.RowScope.EditorToolButton(
     label: String,
@@ -522,10 +523,7 @@ private fun androidx.compose.foundation.layout.RowScope.EditorToolButton(
     onClick: () -> Unit,
 ) {
     OutlinedButton(onClick = onClick, modifier = Modifier.weight(1f), enabled = enabled) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))
-            Text(label, style = MaterialTheme.typography.labelSmall)
-        }
+        Icon(icon, contentDescription = label, modifier = Modifier.size(26.dp))
     }
 }
 


### PR DESCRIPTION
## Summary
- The "Use font on image" editor's Add/Font/Size/Color/Delete toolbar buttons no longer show a text label under the icon — icon only, matching the request to drop the labels.
- Icon size bumped from 18dp to 26dp so each control reads clearly on its own without the label.
- The label string is kept as each button's accessibility `contentDescription` instead of being dropped entirely.

## Test plan
- [ ] Open Use font on image, confirm the toolbar shows only icons (no text) for Add/Font/Size/Color/Delete
- [ ] Confirm icons are noticeably larger than before and still fit comfortably in the row
- [ ] Confirm each button still does the same thing as before (add layer, open font/size/color panel, delete selected layer)
- [ ] Confirm disabled state (Font/Size/Color/Delete with no layer selected) still reads clearly with icon-only styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz

---
_Generated by [Claude Code](https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz)_