### PR TITLE
Use font on image: fix selected/editing text turning invisible

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/ImageTextEditorScreen.kt
@@ -302,7 +302,6 @@ fun ImageTextEditorScreen(
                         // onto a single line as soon as editing ended.
                         drawIntoCanvas { canvas ->
                             layers.forEach { layer ->
-                                if (layer.id == editingLayerId) return@forEach
                                 val paint = overlayPaint(typefaceFor(layer.fontLabel), height * layer.sizePercent / 100f, layer.color.value)
                                 drawOverlayText(
                                     canvas.nativeCanvas, layer.text,


### PR DESCRIPTION
## Summary
- Bug: tapping a text layer in "Use font on image" to select/edit it made its letters disappear (or read as transparent).
- Root cause: the static canvas draw loop explicitly skipped drawing whichever layer was currently being edited (`if (layer.id == editingLayerId) return@forEach`), on the assumption its glyphs were drawn elsewhere. Nothing else ever drew them — the on-canvas `BasicTextField` that hosts the cursor during editing renders its own text fully transparent by design (it exists only to host the cursor/keyboard input, per the comment already on that block). So the moment a layer entered "editing" (which happens immediately on tap/select), its text had nothing left drawing it.
- Fix: removed the skip so every layer is always drawn on the static canvas, matching the existing comment's stated intent ("Always draw the same Paint-based wrapped text ... during editing too").

## Test plan
- [ ] Open Use font on image with an existing text layer, tap it to select — confirm the text stays fully visible (not transparent/hidden)
- [ ] Type more text while it's selected — confirm it stays visible and wraps identically to before/after editing
- [ ] With multiple layers, select each in turn and confirm only the selected one shows the edit box/cursor, while all layers remain visible throughout
- [ ] Export the image and confirm it still matches what was shown on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz

---
_Generated by [Claude Code](https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz)_