### PR TITLE
Fill & Mark: fix Text/Date marks stuck near center when dragged

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -1339,10 +1339,15 @@ private fun markContainsPoint(
  * text box sits.
  */
 private fun textMarkBox(mark: DocumentMark, w: Float): Pair<Float, Float> {
-    val boxWidth = (w * 0.9f).coerceAtMost(w)
+    val boxWidth = w * 0.9f
     val markWidth = mark.sizeFraction * w
     val centerX = mark.offsetX * w + markWidth / 2f
-    val boxLeft = (centerX - boxWidth / 2f).coerceIn(0f, (w - boxWidth).coerceAtLeast(0f))
+    // Deliberately NOT clamped to keep the box fully on-document: at 90% width there'd be only
+    // ~10% of slack to clamp within, so almost any real drag would immediately hit that clamp
+    // and the mark would look stuck near the center no matter how far it was dragged. Letting
+    // the box (and an extreme drag) run past the edges, same as every other mark type already
+    // does, is what makes dragging actually reach the whole document.
+    val boxLeft = centerX - boxWidth / 2f
     return boxLeft to boxWidth
 }
 


### PR DESCRIPTION
## Summary
- The previous fix (#238) made the near-full-width (90% of the document) box for Text/Date marks follow the mark's own position instead of a document-fixed x — but it also clamped that box to stay fully on-document.
- At 90% width, the valid clamp range is only ~10% of the document width, so almost any real drag immediately hit that clamp — the mark visually stayed pinned near the center no matter how far it was actually dragged.
- Removed the clamp. The box (and the mark, at an extreme drag) can now run past the document's edges, same as every other mark type (Check/Signature/Stamp) already allows — that's what actually lets a drag reach the whole document instead of a ~10%-wide sliver around the middle.
- Still starts genuinely centered when a mark is first placed (the underlying math is unchanged there); only the artificial clamp is gone.

## Test plan
- [ ] Add a Text or Date mark, drag it left and right — confirm it now moves freely across the whole document instead of snapping back near the center
- [ ] Drag it near the left/right edges — confirm it can go most of the way to the edge (may run slightly past at the extreme, matching other mark types)
- [ ] Tap it to edit — confirm the editing box still starts centered on wherever it was last dragged to, with no jump
- [ ] Tap away and confirm no reflow/jump between editing and the static preview
- [ ] Export and confirm the exported position matches the on-screen position

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz

---
_Generated by [Claude Code](https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz)_