### PR TITLE
Fill & Mark: fix hand-drawn signature edges getting clipped

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FillMarkScreen.kt
@@ -1658,8 +1658,15 @@ private fun renderStrokeSignatureToBitmap(sig: SavedSignature): Bitmap? {
     val minY = pts.minOf { it.y }
     val maxX = pts.maxOf { it.x }
     val maxY = pts.maxOf { it.y }
-    val w = (maxX - minX).coerceAtLeast(1f).toInt()
-    val h = (maxY - minY).coerceAtLeast(1f).toInt()
+    val rawW = (maxX - minX).coerceAtLeast(1f)
+    val rawH = (maxY - minY).coerceAtLeast(1f)
+    val strokeWidth = maxOf(2f, rawW * 0.03f)
+    // A stroke running along the tight bounding box's own edge is centered exactly on that
+    // edge, so half its width falls outside [minX,maxX]/[minY,maxY] -- padding by half the
+    // stroke width (plus a pixel of slack) keeps it from being clipped by the bitmap's bounds.
+    val pad = strokeWidth / 2f + 1f
+    val w = (rawW + pad * 2f).toInt()
+    val h = (rawH + pad * 2f).toInt()
     val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bitmap)
     val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
@@ -1667,13 +1674,13 @@ private fun renderStrokeSignatureToBitmap(sig: SavedSignature): Bitmap? {
         style = Paint.Style.STROKE
         strokeCap = Paint.Cap.ROUND
         strokeJoin = Paint.Join.ROUND
-        strokeWidth = maxOf(2f, w * 0.03f)
+        this.strokeWidth = strokeWidth
     }
     sig.strokes.forEach { stroke ->
         val first = stroke.points.firstOrNull() ?: return@forEach
         val path = android.graphics.Path().apply {
-            moveTo(first.x - minX, first.y - minY)
-            stroke.points.drop(1).forEach { pt -> lineTo(pt.x - minX, pt.y - minY) }
+            moveTo(first.x - minX + pad, first.y - minY + pad)
+            stroke.points.drop(1).forEach { pt -> lineTo(pt.x - minX + pad, pt.y - minY + pad) }
         }
         canvas.drawPath(path, paint)
     }


### PR DESCRIPTION
## Summary
- Bug: placing a hand-drawn signature (one saved as strokes, not an imported image) in Fill & Mark showed its outer edges cut off.
- Root cause: `renderStrokeSignatureToBitmap` sized the intermediate bitmap to the exact tight bounding box of the raw stroke coordinates, with zero margin. A stroke running along that box's own edge is centered exactly on the boundary, so half its rendered width (the stroke has real thickness) fell outside the bitmap and was clipped by the bitmap's own bounds — not by anything intentional.
- Fix: pad the bitmap by half the stroke width (+1px slack) on every side, and offset the drawn paths by that same padding, so no stroke can be clipped.
- Scope: this only affects strokes-only signatures rendered for Fill & Mark's on-screen preview (the cache in `FillMarkScreen.kt`). The export path (`drawSignature` in `DocumentUtils.kt`) draws strokes directly onto the full page canvas with no intermediate cropped bitmap, so it isn't affected by this bug.

## Test plan
- [ ] Draw a signature with strokes that reach close to the edges of the drawing canvas, save it
- [ ] Place it in Fill & Mark and confirm the full signature — including strokes near its bounding edges — renders without any clipped/cut edges
- [ ] Confirm this still looks correct at different mark sizes (drag the size slider)
- [ ] Confirm export still matches what's shown on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz

---
_Generated by [Claude Code](https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz)_