### PR TITLE
Fonts: clear the stale "imported" notice after deleting a font

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/FontCreatorViewModel.kt
@@ -458,6 +458,9 @@ class FontCreatorViewModel(application: Application) : AndroidViewModel(applicat
             importedFonts.removeAt(idx)
             persistImportedFonts()
             executor.execute { File(getApplication<Application>().filesDir, font.fileName).delete() }
+            // Otherwise a leftover "<name> imported." from whenever this font was first added
+            // stays on screen after deleting it, reading like the deletion itself said so.
+            importStatus = "\"${font.displayName}\" deleted."
         }
     }
 


### PR DESCRIPTION
## Summary
- Bug: after deleting an imported font, a message reading `"<name>" imported.` was still showing on the Fonts screen — confusing, since it looks like the deletion itself produced that notice.
- Root cause: the Fonts screen displays `vm.importStatus` persistently once it's set (from a prior successful import), and `deleteImportedFont()` never touched it — so whatever import message was last shown just stayed on screen indefinitely, including through an unrelated later deletion.
- Fix: `deleteImportedFont()` now sets `importStatus` to a proper `"<name>" deleted.` message, matching the existing pattern used for hand-drawn font project deletion.

## Test plan
- [ ] Import a font (confirm the `"<name>" imported.` message appears)
- [ ] Delete that same font (or any imported font) without navigating away first
- [ ] Confirm the message now reads `"<name>" deleted.` instead of the stale "imported" text lingering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz

---
_Generated by [Claude Code](https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz)_