### PR TITLE
Signature edit: icon-only Clear/Undo/Cancel to stop Save wrapping

### DIFF
--- a/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignatureScreen.kt
+++ b/app/src/main/java/com/jaafar/remoteconfig/fontcreator/SignatureScreen.kt
@@ -24,7 +24,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material.icons.filled.Undo
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
@@ -323,8 +326,14 @@ internal fun SignatureEditorScreen(
                 }
             }
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = { strokes = emptyList(); active = emptyList() }, enabled = strokes.isNotEmpty()) { Text("Clear") }
-                OutlinedButton(onClick = { strokes = strokes.dropLast(1) }, enabled = strokes.isNotEmpty()) { Text("Undo") }
+                // Icon-only -- Clear/Undo/Cancel alongside a full-width "Save changes" made that
+                // label wrap onto two lines; the icons alone read clearly enough on their own.
+                OutlinedButton(onClick = { strokes = emptyList(); active = emptyList() }, enabled = strokes.isNotEmpty()) {
+                    Icon(Icons.Filled.Replay, contentDescription = "Clear")
+                }
+                OutlinedButton(onClick = { strokes = strokes.dropLast(1) }, enabled = strokes.isNotEmpty()) {
+                    Icon(Icons.Filled.Undo, contentDescription = "Undo")
+                }
                 // Only a saved signature has a view to cancel back to -- a brand-new one has
                 // nowhere to go back to, so it has no Cancel.
                 if (current != null) {
@@ -334,7 +343,7 @@ internal fun SignatureEditorScreen(
                         name = current!!.name
                         status = ""
                         isEditing = false
-                    }) { Text("Cancel") }
+                    }) { Icon(Icons.Filled.Close, contentDescription = "Cancel") }
                 }
                 Button(
                     onClick = {


### PR DESCRIPTION
## Summary
- Bug: in the signature editor's edit mode, "Save changes" was wrapping onto two lines — Clear, Undo, Cancel (text buttons) and the full-width Save button no longer fit comfortably on one row.
- Fix: Clear, Undo, and Cancel are now icon-only (reset/undo/close icons, matching the same three controls' icons already used on iOS), freeing up enough width for "Save changes" to fit on a single line.

## Test plan
- [ ] Open an existing signature, tap Edit — confirm Clear/Undo/Cancel show as icons only
- [ ] Confirm "Save changes" now fits on one line
- [ ] Confirm each icon button still does the same thing as before (clear the drawing, undo the last stroke, cancel back to the read-only preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz

---
_Generated by [Claude Code](https://claude.ai/code/session_018pKpxgLoXgRxyTL1bz2gzz)_